### PR TITLE
Stop getUpdates longpolling on Bot::stop

### DIFF
--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -2214,13 +2214,16 @@ namespace tgbotxx {
     /// with an offset higher than its update_id. The negative offset can be specified to retrieve updates
     /// starting from -offset update from the end of the updates queue. All previous updates will be forgotten.
     /// @param limit Limits the number of updates to be retrieved. Values between 1-100 are accepted. Defaults to 100.
+    /// @param stop Flag used to stop long polling.
     /// @returns an Array of Update objects.
     /// @throws Exception on failure
     /// @note Please note that this parameter doesn't affect updates created before the call to the getUpdates, so unwanted updates may be received for a short period of time.
     /// @note This method will not work if an outgoing webhook is set up.
     /// @note In order to avoid getting duplicate updates, recalculate offset after each server response.
     /// @link ref https://core.telegram.org/bots/api#getupdates @endlink
-    std::vector<Ptr<Update>> getUpdates(std::int32_t offset, std::int32_t limit = 100) const;
+    std::vector<Ptr<Update>> getUpdates(std::int32_t offset,
+                                        std::int32_t limit = 100,
+                                        std::shared_ptr<std::atomic<bool>> stop = {}) const;
 
     /// @brief Use this method to specify a URL and receive incoming updates via an outgoing webhook.
     /// Whenever there is an update for the bot, we will send an HTTPS POST request to the specified URL, containing a JSON-serialized Update.
@@ -2823,6 +2826,8 @@ namespace tgbotxx {
     const Cache& getCache() const noexcept;
 
   private:
-    nl::json sendRequest(const std::string& endpoint, const cpr::Multipart& data = cpr::Multipart({})) const;
+    nl::json sendRequest(const std::string& endpoint,
+                         const cpr::Multipart& data = cpr::Multipart({}),
+                         std::shared_ptr<std::atomic<bool>> stop = {}) const;
   };
 }

--- a/include/tgbotxx/Bot.hpp
+++ b/include/tgbotxx/Bot.hpp
@@ -32,7 +32,7 @@ namespace tgbotxx {
       Ptr<Api> m_api{};
       std::vector<Ptr<Update>> m_updates{};
       std::int32_t m_lastUpdateId{};
-      std::atomic<bool> m_running{};
+      std::shared_ptr<std::atomic<bool>> m_stopped{};
 
     public:
       /// @brief Constructs a new Bot object

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <memory>
 #include <tgbotxx/Api.hpp>
 #include <tgbotxx/Bot.hpp>
 #include <tgbotxx/Exception.hpp>
@@ -69,7 +70,7 @@ const cpr::Timeout Api::DEFAULT_LONG_POLL_TIMEOUT = std::chrono::seconds(60);   
 const cpr::Timeout Api::DEFAULT_UPLOAD_FILES_TIMEOUT = std::chrono::seconds(15 * 60);          /// 15min (Files can take longer time to upload. Setting a shorter timeout will stop the request even if the file isn't fully uploaded)
 const cpr::Timeout Api::DEFAULT_DOWNLOAD_FILES_TIMEOUT = std::chrono::seconds(30 * 60);        /// 30min (Files can take longer time to download. Setting a shorter timeout will stop the request even if the file isn't fully downloaded)
 
-void Api::Cache::refresh(const Api* api) {
+void Api::Cache::refresh(const Api *api) {
   // Cache Bot's username & commands
   botUsername = api->getMe()->username;
   if (const auto cmds = api->getMyCommands(); !cmds.empty()) {
@@ -84,10 +85,15 @@ Api::Api(const std::string& token) : m_token(token) {
   m_cache.refresh(this);
 }
 
-nl::json Api::sendRequest(const std::string& endpoint, const cpr::Multipart& data) const {
+nl::json Api::sendRequest(const std::string& endpoint, const cpr::Multipart& data, std::shared_ptr<std::atomic<bool>> stop) const {
   cpr::Session session{}; // Note: Why not have one session as a class member to use for all requests ?
                           // You can initiate multiple concurrent requests to the Telegram API, which means
                           // You can call sendMessage while getUpdates long polling is still pending, and you can't do that with a single cpr::Session instance.
+
+  if (stop) {
+    session.SetCancellationParam(stop);
+  }
+
   const bool hasFiles = std::ranges::any_of(data.parts, [](const cpr::Part& part) noexcept { return part.is_file; });
   session.SetProxies(m_proxies);
   session.SetConnectTimeout(m_connectTimeout);
@@ -1995,7 +2001,7 @@ bool Api::answerCallbackQuery(const std::string& callbackQueryId,
 }
 
 Ptr<UserChatBoosts> Api::getUserChatBoosts(const std::variant<std::int64_t, std::string>& chatId,
-                                       std::int64_t userId) const {
+                                           std::int64_t userId) const {
   cpr::Multipart data{};
   data.parts.reserve(2);
   data.parts.emplace_back("chat_id", chatId.index() == 0 ? std::to_string(std::get<0>(chatId)) : std::get<1>(chatId));
@@ -2589,7 +2595,7 @@ bool Api::deleteWebhook(bool dropPendingUpdates) const {
 }
 
 /// Called every LONG_POOL_TIMEOUT seconds
-std::vector<Ptr<Update>> Api::getUpdates(std::int32_t offset, std::int32_t limit) const {
+std::vector<Ptr<Update>> Api::getUpdates(std::int32_t offset, std::int32_t limit, std::shared_ptr<std::atomic<bool>> running) const {
   std::vector<Ptr<Update>> updates;
   const cpr::Multipart data = {
     {"offset", offset},
@@ -2597,7 +2603,7 @@ std::vector<Ptr<Update>> Api::getUpdates(std::int32_t offset, std::int32_t limit
     {"timeout", static_cast<std::int32_t>(std::chrono::duration_cast<std::chrono::seconds>(m_longPollTimeout.ms).count())},
     {"allowed_updates", nl::json(m_allowedUpdates).dump()},
   };
-  const nl::json updatesJson = sendRequest("getUpdates", data);
+  const nl::json updatesJson = sendRequest("getUpdates", data, running);
   updates.reserve(updatesJson.size());
   for (const nl::json& updateObj: updatesJson) {
     Ptr<Update> update = makePtr<Update>(updateObj);


### PR DESCRIPTION
Formerly when `Bot::stop` gets called the former `Bot::m_running` variable is set to false, but any underlying `cpr::Session::Get/Post` will block until timing out.

Currently, we set an optional cancellation token from `Bot` in `Api::sendRequest` so that for `Api::getUpdates` we can exit immediately after `Bot::stop` is called, without having to call `std::exit`.