### PR TITLE
Merge V1.2.9.5_dev into main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(tgbotxx VERSION "1.2.9.2" DESCRIPTION "Telegram Bot C++ Library" LANGUAGES C CXX)
+project(tgbotxx VERSION "1.2.9.5" DESCRIPTION "Telegram Bot C++ Library" LANGUAGES C CXX)
 # Note: tgbotxx version's patch & build is based on Telegram Bot Api version for compatibility. See https://core.telegram.org/bots/api-changelog
 # <OurMajorVersion>.<OurMinorVersion>.<TelegramBotApiMajorVersion>.<TelegramBotApiMinorVersion>
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 GitHub contributors https://github.com/baderouaich/tgbotxx/graphs/contributors
+Copyright (c) 2026 GitHub contributors https://github.com/baderouaich/tgbotxx/graphs/contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Telegram Bot C++ Library
 
 ## Features
-- Compatible with Telegram [Bot API 9.2 (August 15, 2025)](https://core.telegram.org/bots/api-changelog)
+- Compatible with Telegram [Bot API 9.5 (March 1, 2026)](https://core.telegram.org/bots/api-changelog#march-1-2026)
 - Simple, Fast and Reliable.
 - Uses [libcpr](https://github.com/libcpr/cpr) for HTTP requests and [nlohmann::json](https://github.com/nlohmann/json) for JSON parsing (Both are exposed to the user by default)
 - Cross Platform (Ubuntu, Windows and macOS)
@@ -127,7 +127,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG "v1.2.9.2" # Compatible with Telegram Api 9.2
+        GIT_TAG "v1.2.9.5" # Compatible with Telegram Api 9.5
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/TODO_TG_API_v9_5.md
+++ b/TODO_TG_API_v9_5.md
@@ -45,35 +45,35 @@
 # 9.4
 
 ### Custom Emoji
-- [ ] Allowed bots to use custom emoji in messages directly sent by the bot to private, group and supergroup chats if the owner of the bot has a Telegram Premium subscription.
+- [x] Allowed bots to use custom emoji in messages directly sent by the bot to private, group and supergroup chats if the owner of the bot has a Telegram Premium subscription.
 
 ### Topics in Private Chats
-- [ ] Allowed bots to create topics in private chats using the method `createForumTopic`.
-- [ ] Allowed bots to prevent users from creating and deleting topics in private chats through a new setting in the @BotFather Mini App.
-- [ ] Added the field `allows_users_to_create_topics` to the class `User`.
+- [x] Allowed bots to create topics in private chats using the method `createForumTopic`.
+- [x] Allowed bots to prevent users from creating and deleting topics in private chats through a new setting in the @BotFather Mini App.
+- [x] Added the field `allows_users_to_create_topics` to the class `User`.
 
 ### Button Improvements
-- [ ] Added the field `icon_custom_emoji_id` to the classes `KeyboardButton` and `InlineKeyboardButton`.
-- [ ] Added the field `style` to the classes `KeyboardButton` and `InlineKeyboardButton`.
+- [x] Added the field `icon_custom_emoji_id` to the classes `KeyboardButton` and `InlineKeyboardButton`.
+- [x] Added the field `style` to the classes `KeyboardButton` and `InlineKeyboardButton`.
 
 ### Chat Ownership
-- [ ] Added the class `ChatOwnerLeft` and the field `chat_owner_left` to the class `Message`.
-- [ ] Added the class `ChatOwnerChanged` and the field `chat_owner_changed` to the class `Message`.
+- [x] Added the class `ChatOwnerLeft` and the field `chat_owner_left` to the class `Message`.
+- [x] Added the class `ChatOwnerChanged` and the field `chat_owner_changed` to the class `Message`.
 
 ### Bot Profile
-- [ ] Added the methods `setMyProfilePhoto` and `removeMyProfilePhoto`.
+- [x] Added the methods `setMyProfilePhoto` and `removeMyProfilePhoto`.
 
 ### Video Improvements
-- [ ] Added the class `VideoQuality` and the field `qualities` to the class `Video`.
+- [x] Added the class `VideoQuality` and the field `qualities` to the class `Video`.
 
 ### Profile Audio
-- [ ] Added the field `first_profile_audio` to the class `ChatFullInfo`.
-- [ ] Added the class `UserProfileAudios`.
-- [ ] Added the method `getUserProfileAudios`.
+- [x] Added the field `first_profile_audio` to the class `ChatFullInfo`.
+- [x] Added the class `UserProfileAudios`.
+- [x] Added the method `getUserProfileAudios`.
 
 ### Gifts
-- [ ] Added the field `rarity` to the class `UniqueGiftModel`.
-- [ ] Added the field `is_burned` to the class `UniqueGift`.
+- [x] Added the field `rarity` to the class `UniqueGiftModel`.
+- [x] Added the field `is_burned` to the class `UniqueGift`.
 
 
 # 9.5

--- a/TODO_TG_API_v9_5.md
+++ b/TODO_TG_API_v9_5.md
@@ -3,11 +3,11 @@
 ### Topics in private chats
 - [x] Added the field `has_topics_enabled` to the class `User`, which can be used to determine whether forum topic mode is enabled for the bot in private chats.
 - [x] Added the method `sendMessageDraft`, allowing partial messages to be streamed to a user while being generated.
-- [ ] Supported the fields `message_thread_id` and `is_topic_message` in the class `Message` for messages in private chats with forum topic mode enabled.
-- [ ] Supported the parameter `message_thread_id` in private chats with topics in the methods `sendMessage`, `sendPhoto`, `sendVideo`, `sendAnimation`, `sendAudio`, `sendDocument`, `sendPaidMedia`, `sendSticker`, `sendVideoNote`, `sendVoice`, `sendLocation`, `sendVenue`, `sendContact`, `sendPoll`, `sendDice`, `sendInvoice`, `sendGame`, `sendMediaGroup`, `copyMessage`, `copyMessages`, `forwardMessage`, and `forwardMessages`.
-- [ ] Supported the parameter `message_thread_id` in private chats in the method `sendChatAction`.
-- [ ] Supported the parameter `message_thread_id` in private chats with topics in the methods `editForumTopic`, `deleteForumTopic`, and `unpinAllForumTopicMessages`.
-- [ ] Added the field `is_name_implicit` to the classes `ForumTopic` and `ForumTopicCreated`.
+- [x] Supported the fields `message_thread_id` and `is_topic_message` in the class `Message` for messages in private chats with forum topic mode enabled.
+- [x] Supported the parameter `message_thread_id` in private chats with topics in the methods `sendMessage`, `sendPhoto`, `sendVideo`, `sendAnimation`, `sendAudio`, `sendDocument`, `sendPaidMedia`, `sendSticker`, `sendVideoNote`, `sendVoice`, `sendLocation`, `sendVenue`, `sendContact`, `sendPoll`, `sendDice`, `sendInvoice`, `sendGame`, `sendMediaGroup`, `copyMessage`, `copyMessages`, `forwardMessage`, and `forwardMessages`.
+- [x] Supported the parameter `message_thread_id` in private chats in the method `sendChatAction`.
+- [x] Supported the parameter `message_thread_id` in private chats with topics in the methods `editForumTopic`, `deleteForumTopic`, and `unpinAllForumTopicMessages`.
+- [x] Added the field `is_name_implicit` to the classes `ForumTopic` and `ForumTopicCreated`.
 
 ### Gifts
 - [ ] Added the methods `getUserGifts` and `getChatGifts`.

--- a/TODO_TG_API_v9_5.md
+++ b/TODO_TG_API_v9_5.md
@@ -31,15 +31,15 @@
 - [x] Added the field `gifts_from_channels` to the class `AcceptedGiftTypes`.
 
 ### Miscellaneous
-- [ ] Allowed bots to disable their main username if they have additional active usernames purchased on Fragment.
-- [ ] Allowed bots to disable the right `can_restrict_members` in channel chats.
-- [ ] Added the method `repostStory`.
-- [ ] Added the class `UserRating` and the field `rating` to the class `ChatFullInfo`.
-- [ ] Increased the maximum price for paid media to 25000 Telegram Stars.
-- [ ] Added the field `paid_message_star_count` to the class `ChatFullInfo`.
-- [ ] Added the parameter `message_effect_id` to the methods `forwardMessage` and `copyMessage`.
-- [ ] Added the field `unique_gift_colors` to the class `ChatFullInfo`.
-- [ ] Added the field `completed_by_chat` to the class `ChecklistTask`.
+- [x] Allowed bots to disable their main username if they have additional active usernames purchased on Fragment.
+- [x] Allowed bots to disable the right `can_restrict_members` in channel chats.
+- [x] Added the method `repostStory`.
+- [x] Added the class `UserRating` and the field `rating` to the class `ChatFullInfo`.
+- [x] Increased the maximum price for paid media to 25000 Telegram Stars.
+- [x] Added the field `paid_message_star_count` to the class `ChatFullInfo`.
+- [x] Added the parameter `message_effect_id` to the methods `forwardMessage` and `copyMessage`.
+- [x] Added the field `unique_gift_colors` to the class `ChatFullInfo`.
+- [x] Added the field `completed_by_chat` to the class `ChecklistTask`.
 
 
 # 9.4

--- a/TODO_TG_API_v9_5.md
+++ b/TODO_TG_API_v9_5.md
@@ -79,18 +79,15 @@
 # 9.5
 
 ### Message Entities
-- [ ] Added the `MessageEntity` type `date_time`, allowing bots to show a formatted date and time to the user.
+- [x] Added the `MessageEntity` type `date_time`, allowing bots to show a formatted date and time to the user.
 
 ### Draft Messages
-- [ ] Allowed all bots to use the method `sendMessageDraft`.
+- [x] Allowed all bots to use the method `sendMessageDraft`.
 
 ### Chat Member Tags
-- [ ] Added the field `tag` to the classes `ChatMemberMember` and `ChatMemberRestricted`.
-- [ ] Added the method `setChatMemberTag`.
-- [ ] Added the field `can_edit_tag` to the classes `ChatMemberRestricted` and `ChatPermissions`.
-- [ ] Added the field `can_manage_tags` to the classes `ChatMemberAdministrator` and `ChatAdministratorRights`.
-- [ ] Added the parameter `can_manage_tags` to the method `promoteChatMember`.
-- [ ] Added the field `sender_tag` to the class `Message`.
-
-### UI
-- [ ] Added the field `iconCustomEmojiId` to the class `BottomButton`.
+- [x] Added the field `tag` to the classes `ChatMemberMember` and `ChatMemberRestricted`.
+- [x] Added the method `setChatMemberTag`.
+- [x] Added the field `can_edit_tag` to the classes `ChatMemberRestricted` and `ChatPermissions`.
+- [x] Added the field `can_manage_tags` to the classes `ChatMemberAdministrator` and `ChatAdministratorRights`.
+- [x] Added the parameter `can_manage_tags` to the method `promoteChatMember`.
+- [x] Added the field `sender_tag` to the class `Message`.

--- a/TODO_TG_API_v9_5.md
+++ b/TODO_TG_API_v9_5.md
@@ -10,7 +10,7 @@
 - [x] Added the field `is_name_implicit` to the classes `ForumTopic` and `ForumTopicCreated`.
 
 ### Gifts
-- [ ] Added the methods `getUserGifts` and `getChatGifts`.
+- [x] Added the methods `getUserGifts` and `getChatGifts`.
 - [ ] Replaced the field `last_resale_star_count` with the fields `last_resale_currency` and `last_resale_amount` in the class `UniqueGiftInfo`.
 - [ ] Replaced the parameter `exclude_limited` with the parameters `exclude_limited_upgradable` and `exclude_limited_non_upgradable` in the method `getBusinessAccountGifts`.
 - [ ] Added the value `"gifted_upgrade"` as a possible value of `UniqueGiftInfo.origin`.

--- a/TODO_TG_API_v9_5.md
+++ b/TODO_TG_API_v9_5.md
@@ -1,0 +1,96 @@
+# 9.3
+
+### Topics in private chats
+- [x] Added the field `has_topics_enabled` to the class `User`, which can be used to determine whether forum topic mode is enabled for the bot in private chats.
+- [x] Added the method `sendMessageDraft`, allowing partial messages to be streamed to a user while being generated.
+- [ ] Supported the fields `message_thread_id` and `is_topic_message` in the class `Message` for messages in private chats with forum topic mode enabled.
+- [ ] Supported the parameter `message_thread_id` in private chats with topics in the methods `sendMessage`, `sendPhoto`, `sendVideo`, `sendAnimation`, `sendAudio`, `sendDocument`, `sendPaidMedia`, `sendSticker`, `sendVideoNote`, `sendVoice`, `sendLocation`, `sendVenue`, `sendContact`, `sendPoll`, `sendDice`, `sendInvoice`, `sendGame`, `sendMediaGroup`, `copyMessage`, `copyMessages`, `forwardMessage`, and `forwardMessages`.
+- [ ] Supported the parameter `message_thread_id` in private chats in the method `sendChatAction`.
+- [ ] Supported the parameter `message_thread_id` in private chats with topics in the methods `editForumTopic`, `deleteForumTopic`, and `unpinAllForumTopicMessages`.
+- [ ] Added the field `is_name_implicit` to the classes `ForumTopic` and `ForumTopicCreated`.
+
+### Gifts
+- [ ] Added the methods `getUserGifts` and `getChatGifts`.
+- [ ] Replaced the field `last_resale_star_count` with the fields `last_resale_currency` and `last_resale_amount` in the class `UniqueGiftInfo`.
+- [ ] Replaced the parameter `exclude_limited` with the parameters `exclude_limited_upgradable` and `exclude_limited_non_upgradable` in the method `getBusinessAccountGifts`.
+- [ ] Added the value `"gifted_upgrade"` as a possible value of `UniqueGiftInfo.origin`.
+- [ ] Added the value `"offer"` as a possible value of `UniqueGiftInfo.origin`.
+- [ ] Added the field `gift_upgrade_sent` to the class `Message`.
+- [ ] Added the field `gift_id` to the class `UniqueGift`.
+- [ ] Added the field `is_from_blockchain` to the class `UniqueGift`.
+- [ ] Added the parameter `exclude_from_blockchain` in the method `getBusinessAccountGifts`.
+- [ ] Added the fields `personal_total_count` and `personal_remaining_count` to the class `Gift`.
+- [ ] Added the field `is_premium` to the classes `Gift` and `UniqueGift`.
+- [ ] Added the field `is_upgrade_separate` to the classes `GiftInfo` and `OwnedGiftRegular`.
+- [ ] Added the class `UniqueGiftColors`.
+- [ ] Added the field `has_colors` to the class `Gift`.
+- [ ] Added the field `colors` to the class `UniqueGift`.
+- [ ] Added the class `GiftBackground` and the field `background` to the class `Gift`.
+- [ ] Added the field `unique_gift_variant_count` to the class `Gift`.
+- [ ] Added the field `unique_gift_number` to the classes `GiftInfo` and `OwnedGiftRegular`.
+- [ ] Added the field `gifts_from_channels` to the class `AcceptedGiftTypes`.
+
+### Miscellaneous
+- [ ] Allowed bots to disable their main username if they have additional active usernames purchased on Fragment.
+- [ ] Allowed bots to disable the right `can_restrict_members` in channel chats.
+- [ ] Added the method `repostStory`.
+- [ ] Added the class `UserRating` and the field `rating` to the class `ChatFullInfo`.
+- [ ] Increased the maximum price for paid media to 25000 Telegram Stars.
+- [ ] Added the field `paid_message_star_count` to the class `ChatFullInfo`.
+- [ ] Added the parameter `message_effect_id` to the methods `forwardMessage` and `copyMessage`.
+- [ ] Added the field `unique_gift_colors` to the class `ChatFullInfo`.
+- [ ] Added the field `completed_by_chat` to the class `ChecklistTask`.
+
+
+# 9.4
+
+### Custom Emoji
+- [ ] Allowed bots to use custom emoji in messages directly sent by the bot to private, group and supergroup chats if the owner of the bot has a Telegram Premium subscription.
+
+### Topics in Private Chats
+- [ ] Allowed bots to create topics in private chats using the method `createForumTopic`.
+- [ ] Allowed bots to prevent users from creating and deleting topics in private chats through a new setting in the @BotFather Mini App.
+- [ ] Added the field `allows_users_to_create_topics` to the class `User`.
+
+### Button Improvements
+- [ ] Added the field `icon_custom_emoji_id` to the classes `KeyboardButton` and `InlineKeyboardButton`.
+- [ ] Added the field `style` to the classes `KeyboardButton` and `InlineKeyboardButton`.
+
+### Chat Ownership
+- [ ] Added the class `ChatOwnerLeft` and the field `chat_owner_left` to the class `Message`.
+- [ ] Added the class `ChatOwnerChanged` and the field `chat_owner_changed` to the class `Message`.
+
+### Bot Profile
+- [ ] Added the methods `setMyProfilePhoto` and `removeMyProfilePhoto`.
+
+### Video Improvements
+- [ ] Added the class `VideoQuality` and the field `qualities` to the class `Video`.
+
+### Profile Audio
+- [ ] Added the field `first_profile_audio` to the class `ChatFullInfo`.
+- [ ] Added the class `UserProfileAudios`.
+- [ ] Added the method `getUserProfileAudios`.
+
+### Gifts
+- [ ] Added the field `rarity` to the class `UniqueGiftModel`.
+- [ ] Added the field `is_burned` to the class `UniqueGift`.
+
+
+# 9.5
+
+### Message Entities
+- [ ] Added the `MessageEntity` type `date_time`, allowing bots to show a formatted date and time to the user.
+
+### Draft Messages
+- [ ] Allowed all bots to use the method `sendMessageDraft`.
+
+### Chat Member Tags
+- [ ] Added the field `tag` to the classes `ChatMemberMember` and `ChatMemberRestricted`.
+- [ ] Added the method `setChatMemberTag`.
+- [ ] Added the field `can_edit_tag` to the classes `ChatMemberRestricted` and `ChatPermissions`.
+- [ ] Added the field `can_manage_tags` to the classes `ChatMemberAdministrator` and `ChatAdministratorRights`.
+- [ ] Added the parameter `can_manage_tags` to the method `promoteChatMember`.
+- [ ] Added the field `sender_tag` to the class `Message`.
+
+### UI
+- [ ] Added the field `iconCustomEmojiId` to the class `BottomButton`.

--- a/TODO_TG_API_v9_5.md
+++ b/TODO_TG_API_v9_5.md
@@ -13,22 +13,22 @@
 - [x] Added the methods `getUserGifts` and `getChatGifts`.
 - [x] Replaced the field `last_resale_star_count` with the fields `last_resale_currency` and `last_resale_amount` in the class `UniqueGiftInfo`.
 - [x] Replaced the parameter `exclude_limited` with the parameters `exclude_limited_upgradable` and `exclude_limited_non_upgradable` in the method `getBusinessAccountGifts`.
-- [ ] Added the value `"gifted_upgrade"` as a possible value of `UniqueGiftInfo.origin`.
-- [ ] Added the value `"offer"` as a possible value of `UniqueGiftInfo.origin`.
-- [ ] Added the field `gift_upgrade_sent` to the class `Message`.
-- [ ] Added the field `gift_id` to the class `UniqueGift`.
-- [ ] Added the field `is_from_blockchain` to the class `UniqueGift`.
-- [ ] Added the parameter `exclude_from_blockchain` in the method `getBusinessAccountGifts`.
-- [ ] Added the fields `personal_total_count` and `personal_remaining_count` to the class `Gift`.
-- [ ] Added the field `is_premium` to the classes `Gift` and `UniqueGift`.
-- [ ] Added the field `is_upgrade_separate` to the classes `GiftInfo` and `OwnedGiftRegular`.
-- [ ] Added the class `UniqueGiftColors`.
-- [ ] Added the field `has_colors` to the class `Gift`.
-- [ ] Added the field `colors` to the class `UniqueGift`.
-- [ ] Added the class `GiftBackground` and the field `background` to the class `Gift`.
-- [ ] Added the field `unique_gift_variant_count` to the class `Gift`.
-- [ ] Added the field `unique_gift_number` to the classes `GiftInfo` and `OwnedGiftRegular`.
-- [ ] Added the field `gifts_from_channels` to the class `AcceptedGiftTypes`.
+- [x] Added the value `"gifted_upgrade"` as a possible value of `UniqueGiftInfo.origin`.
+- [x] Added the value `"offer"` as a possible value of `UniqueGiftInfo.origin`.
+- [x] Added the field `gift_upgrade_sent` to the class `Message`.
+- [x] Added the field `gift_id` to the class `UniqueGift`.
+- [x] Added the field `is_from_blockchain` to the class `UniqueGift`.
+- [x] Added the parameter `exclude_from_blockchain` in the method `getBusinessAccountGifts`.
+- [x] Added the fields `personal_total_count` and `personal_remaining_count` to the class `Gift`.
+- [x] Added the field `is_premium` to the classes `Gift` and `UniqueGift`.
+- [x] Added the field `is_upgrade_separate` to the classes `GiftInfo` and `OwnedGiftRegular`.
+- [x] Added the class `UniqueGiftColors`.
+- [x] Added the field `has_colors` to the class `Gift`.
+- [x] Added the field `colors` to the class `UniqueGift`.
+- [x] Added the class `GiftBackground` and the field `background` to the class `Gift`.
+- [x] Added the field `unique_gift_variant_count` to the class `Gift`.
+- [x] Added the field `unique_gift_number` to the classes `GiftInfo` and `OwnedGiftRegular`.
+- [x] Added the field `gifts_from_channels` to the class `AcceptedGiftTypes`.
 
 ### Miscellaneous
 - [ ] Allowed bots to disable their main username if they have additional active usernames purchased on Fragment.

--- a/TODO_TG_API_v9_5.md
+++ b/TODO_TG_API_v9_5.md
@@ -11,8 +11,8 @@
 
 ### Gifts
 - [x] Added the methods `getUserGifts` and `getChatGifts`.
-- [ ] Replaced the field `last_resale_star_count` with the fields `last_resale_currency` and `last_resale_amount` in the class `UniqueGiftInfo`.
-- [ ] Replaced the parameter `exclude_limited` with the parameters `exclude_limited_upgradable` and `exclude_limited_non_upgradable` in the method `getBusinessAccountGifts`.
+- [x] Replaced the field `last_resale_star_count` with the fields `last_resale_currency` and `last_resale_amount` in the class `UniqueGiftInfo`.
+- [x] Replaced the parameter `exclude_limited` with the parameters `exclude_limited_upgradable` and `exclude_limited_non_upgradable` in the method `getBusinessAccountGifts`.
 - [ ] Added the value `"gifted_upgrade"` as a possible value of `UniqueGiftInfo.origin`.
 - [ ] Added the value `"offer"` as a possible value of `UniqueGiftInfo.origin`.
 - [ ] Added the field `gift_upgrade_sent` to the class `Message`.

--- a/examples/Buttons/InlineKeyboardButton/CMakeLists.txt
+++ b/examples/Buttons/InlineKeyboardButton/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/Buttons/ReplyKeyboardMarkup/CMakeLists.txt
+++ b/examples/Buttons/ReplyKeyboardMarkup/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/EarthquakeBot/CMakeLists.txt
+++ b/examples/EarthquakeBot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/EchoBot/CMakeLists.txt
+++ b/examples/EchoBot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG        "v1.2.9.2"
+        GIT_TAG        "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/PaidSubscriptionBot/CMakeLists.txt
+++ b/examples/PaidSubscriptionBot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/PingBot/CMakeLists.txt
+++ b/examples/PingBot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/QrCodeBot/CMakeLists.txt
+++ b/examples/QrCodeBot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/ThreadPoolBot/CMakeLists.txt
+++ b/examples/ThreadPoolBot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG "v1.2.9.2"
+        GIT_TAG "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/UrlShortenerBot/CMakeLists.txt
+++ b/examples/UrlShortenerBot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/WeatherBot/CMakeLists.txt
+++ b/examples/WeatherBot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/receiveAudio/CMakeLists.txt
+++ b/examples/receiveAudio/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/receiveDocument/CMakeLists.txt
+++ b/examples/receiveDocument/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/receivePhoto/CMakeLists.txt
+++ b/examples/receivePhoto/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/receiveVideo/CMakeLists.txt
+++ b/examples/receiveVideo/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/sendAudio/CMakeLists.txt
+++ b/examples/sendAudio/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/sendDocument/CMakeLists.txt
+++ b/examples/sendDocument/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/sendPhoto/CMakeLists.txt
+++ b/examples/sendPhoto/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/sendPoll/CMakeLists.txt
+++ b/examples/sendPoll/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/examples/sendVideo/CMakeLists.txt
+++ b/examples/sendVideo/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(tgbotxx
         GIT_REPOSITORY "https://github.com/baderouaich/tgbotxx"
-        GIT_TAG         "v1.2.9.2"
+        GIT_TAG         "v1.2.9.5"
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL

--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -182,6 +182,7 @@ namespace tgbotxx {
     /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param disableNotification Optional. Sends the message silently. Users will receive a notification with no sound.
     /// @param protectContent Optional. Protects the contents of the forwarded message from forwarding and saving
+    /// @param messageEffectId Optional. Unique identifier of the message effect to be added to the message; only available when forwarding to private chats
     /// @param directMessagesTopicId Optional. Identifier of the direct messages topic to which the message will be forwarded; required if the message is forwarded to a direct messages chat
     /// @param videoStartTimestamp Optional. New start timestamp for the forwarded video in the message
     /// @param suggestedPostParameters Optional. A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only
@@ -194,6 +195,7 @@ namespace tgbotxx {
                                 std::int32_t messageThreadId = 0,
                                 bool disableNotification = false,
                                 bool protectContent = false,
+                                const std::string& messageEffectId = "",
                                 std::int32_t directMessagesTopicId = 0,
                                 std::time_t videoStartTimestamp = 0,
                                 const Ptr<SuggestedPostParameters>& suggestedPostParameters = nullptr) const;
@@ -238,6 +240,7 @@ namespace tgbotxx {
     /// @param captionEntities Optional. A JSON-serialized list of special entities that appear in the new caption, which can be specified instead of parseMode
     /// @param disableNotification Optional. Sends the message silently. Users will receive a notification with no sound.
     /// @param protectContent Optional. Protects the contents of the sent message from forwarding and saving
+    /// @param messageEffectId Optional. Unique identifier of the message effect to be added to the message; only available when copying to private chats
     /// @param replyMarkup Optional. Additional interface options. One of InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, or ForceReply
     /// @param directMessagesTopicId Optional. Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
     /// @param videoStartTimestamp Optional. New start timestamp for the copied video in the message
@@ -257,6 +260,7 @@ namespace tgbotxx {
                                const std::vector<Ptr<MessageEntity>>& captionEntities = std::vector<Ptr<MessageEntity>>(),
                                bool disableNotification = false,
                                bool protectContent = false,
+                               const std::string& messageEffectId = "",
                                const Ptr<IReplyMarkup>& replyMarkup = nullptr,
                                std::int32_t directMessagesTopicId = 0,
                                std::time_t videoStartTimestamp = 0,
@@ -2056,6 +2060,25 @@ namespace tgbotxx {
                          const std::vector<Ptr<StoryArea>>& areas = std::vector<Ptr<StoryArea>>(),
                          bool postToChatPage = false,
                          bool protectContent = false) const;
+
+    /// @brief Reposts a story on behalf of a business account from another business account.
+    /// Both business accounts must be managed by the same bot, and the story on the source account must have been posted (or reposted) by the bot.
+    /// Requires the can_manage_stories business bot right for both business accounts.
+    /// @param businessConnectionId Unique identifier of the business connection
+    /// @param fromChatId Unique identifier of the chat which posted the story that should be reposted
+    /// @param fromStoryId Unique identifier of the story that should be reposted
+    /// @param activePeriod Period after which the story is moved to the archive, in seconds; must be one of 6 * 3600, 12 * 3600, 86400, or 2 * 86400
+    /// @param postToChatPage Optional. Pass True to keep the story accessible after it expires
+    /// @param protectContent Optional. Pass True if the content of the story must be protected from forwarding and screenshotting
+    /// @throws Exception on failure
+    /// @returns Story on success.
+    /// @ref https://core.telegram.org/bots/api#repoststory
+    Ptr<Story> repostStory(const std::string& businessConnectionId,
+                          std::int64_t fromChatId,
+                          std::int32_t fromStoryId,
+                          std::time_t activePeriod,
+                          bool postToChatPage = false,
+                          bool protectContent = false) const;
 
     /// @brief Edits a story previously posted by the bot on behalf of a managed business account. Requires the can_manage_stories business bot right.
     /// @param businessConnectionId Unique identifier of the business connection

--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -1778,6 +1778,56 @@ namespace tgbotxx {
                                  const std::string& textParseMode = "",
                                  const std::vector<Ptr<MessageEntity>>& textEntities = std::vector<Ptr<MessageEntity>>()) const;
 
+    /// @brief Returns the gifts owned and hosted by a user.
+    /// @param userId Unique identifier of the user
+    /// @param excludeUnlimited Optional. Pass True to exclude gifts that can be purchased an unlimited number of times
+    /// @param excludeLimitedUpgradable Optional. Pass True to exclude gifts that can be purchased a limited number of times and can be upgraded to unique
+    /// @param excludeLimitedNonUpgradable Optional. Pass True to exclude gifts that can be purchased a limited number of times and can't be upgraded to unique
+    /// @param excludeFromBlockchain Optional. Pass True to exclude gifts that were assigned from the TON blockchain and can't be resold or transferred in Telegram
+    /// @param excludeUnique Optional. Pass True to exclude unique gifts
+    /// @param sortByPrice Optional. Pass True to sort results by gift price instead of send date. Sorting is applied before pagination.
+    /// @param offset Optional. Offset of the first entry to return as received from the previous request; use an empty string to get the first chunk of results
+    /// @param limit Optional. The maximum number of gifts to be returned; 1-100. Defaults to 100
+    /// @throws Exception on failure
+    /// @returns OwnedGifts on success.
+    /// @ref https://core.telegram.org/bots/api#getusergifts
+    Ptr<OwnedGifts> getUserGifts(std::int64_t userId,
+                                 bool excludeUnlimited = false,
+                                 bool excludeLimitedUpgradable = false,
+                                 bool excludeLimitedNonUpgradable = false,
+                                 bool excludeFromBlockchain = false,
+                                 bool excludeUnique = false,
+                                 bool sortByPrice = false,
+                                 const std::string& offset = "",
+                                 std::int32_t limit = 100) const;
+
+    /// @brief Returns the gifts owned by a chat.
+    /// @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+    /// @param excludeUnsaved Optional. Pass True to exclude gifts that aren't saved to the chat's profile page. Always True, unless the bot has the can_post_messages administrator right in the channel.
+    /// @param excludeSaved Optional. Pass True to exclude gifts that are saved to the chat's profile page. Always False, unless the bot has the can_post_messages administrator right in the channel.
+    /// @param excludeUnlimited Optional. Pass True to exclude gifts that can be purchased an unlimited number of times
+    /// @param excludeLimitedUpgradable Optional. Pass True to exclude gifts that can be purchased a limited number of times and can be upgraded to unique
+    /// @param excludeLimitedNonUpgradable Optional. Pass True to exclude gifts that can be purchased a limited number of times and can't be upgraded to unique
+    /// @param excludeFromBlockchain Optional. Pass True to exclude gifts that were assigned from the TON blockchain and can't be resold or transferred in Telegram
+    /// @param excludeUnique Optional. Pass True to exclude unique gifts
+    /// @param sortByPrice Optional. Pass True to sort results by gift price instead of send date. Sorting is applied before pagination.
+    /// @param offset Optional. Offset of the first entry to return as received from the previous request; use an empty string to get the first chunk of results
+    /// @param limit Optional. The maximum number of gifts to be returned; 1-100. Defaults to 100
+    /// @throws Exception on failure
+    /// @returns OwnedGifts on success.
+    /// @ref https://core.telegram.org/bots/api#getchatgifts
+    Ptr<OwnedGifts> getChatGifts(const std::variant<std::int64_t, std::string>& chatId,
+                                 bool excludeUnsaved = false,
+                                 bool excludeSaved = false,
+                                 bool excludeUnlimited = false,
+                                 bool excludeLimitedUpgradable = false,
+                                 bool excludeLimitedNonUpgradable = false,
+                                 bool excludeFromBlockchain = false,
+                                 bool excludeUnique = false,
+                                 bool sortByPrice = false,
+                                 const std::string& offset = "",
+                                 std::int32_t limit = 100) const;
+
   public: // Verification
     /// @brief Verifies a user on behalf of the organization which is represented by the bot.
     /// @param userId Unique identifier of the target user

--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -1973,7 +1973,8 @@ namespace tgbotxx {
     /// @param excludeUnsaved Optional. Pass True to exclude gifts that aren't saved to the account's profile page
     /// @param excludeSaved Optional. Pass True to exclude gifts that are saved to the account's profile page
     /// @param excludeUnlimited Optional. Pass True to exclude gifts that can be purchased an unlimited number of times
-    /// @param excludeLimited Optional. Pass True to exclude gifts that can be purchased a limited number of times
+    /// @param excludeLimitedUpgradable Optional. Pass True to exclude gifts that can be purchased a limited number of times and can be upgraded to unique
+    /// @param excludeLimitedNonUpgradable Optional. Pass True to exclude gifts that can be purchased a limited number of times and can't be upgraded to unique
     /// @param excludeUnique Optional. Pass True to exclude unique gifts
     /// @param sortByPrice Optional. Pass True to sort results by gift price instead of send date. Sorting is applied before pagination.
     /// @param offset Optional. Offset of the first entry to return as received from the previous request;
@@ -1986,7 +1987,8 @@ namespace tgbotxx {
                                             bool excludeUnsaved = false,
                                             bool excludeSaved = false,
                                             bool excludeUnlimited = false,
-                                            bool excludeLimited = false,
+                                            bool excludeLimitedUpgradable = false,
+                                            bool excludeLimitedNonUpgradable = false,
                                             bool excludeUnique = false,
                                             bool sortByPrice = false,
                                             const std::string& offset = "",

--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -1976,6 +1976,7 @@ namespace tgbotxx {
     /// @param excludeLimitedUpgradable Optional. Pass True to exclude gifts that can be purchased a limited number of times and can be upgraded to unique
     /// @param excludeLimitedNonUpgradable Optional. Pass True to exclude gifts that can be purchased a limited number of times and can't be upgraded to unique
     /// @param excludeUnique Optional. Pass True to exclude unique gifts
+    /// @param excludeFromBlockchain Optional. Pass True to exclude gifts that were assigned from the TON blockchain and can't be resold or transferred in Telegram
     /// @param sortByPrice Optional. Pass True to sort results by gift price instead of send date. Sorting is applied before pagination.
     /// @param offset Optional. Offset of the first entry to return as received from the previous request;
     ///               use empty string to get the first chunk of results
@@ -1990,6 +1991,7 @@ namespace tgbotxx {
                                             bool excludeLimitedUpgradable = false,
                                             bool excludeLimitedNonUpgradable = false,
                                             bool excludeUnique = false,
+                                            bool excludeFromBlockchain = false,
                                             bool sortByPrice = false,
                                             const std::string& offset = "",
                                             std::int32_t limit = 100) const;

--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -19,6 +19,7 @@ namespace tgbotxx {
   struct MessageId;
   struct InputMedia;
   struct UserProfilePhotos;
+  struct UserProfileAudios;
   struct File;
   struct ChatMember;
   struct ChatPermissions;
@@ -998,6 +999,17 @@ namespace tgbotxx {
                                                 std::int32_t offset = 0,
                                                 std::int32_t limit = 100) const;
 
+    /// @brief Use this method to get a list of profile audios for a user.
+    /// @param userId Unique identifier of the target user
+    /// @param offset Optional. Sequential number of the first audio to be returned. By default, all audios are returned.
+    /// @param limit Optional. Limits the number of audios to be retrieved. Values between 1-100 are accepted. Defaults to 100.
+    /// @returns a UserProfileAudios object.
+    /// @throws Exception on failure
+    /// @ref https://core.telegram.org/bots/api#getuserprofilephotos
+    Ptr<UserProfileAudios> getUserProfileAudios(std::int64_t userId,
+                                                std::int32_t offset = 0,
+                                                std::int32_t limit = 100) const;
+
 
     /// @brief Use this method to get basic information about a file and prepare it for downloading.
     /// For the moment, bots can download files of up to 20MB in size.
@@ -1455,8 +1467,9 @@ namespace tgbotxx {
     std::vector<Ptr<Sticker>> getForumTopicIconStickers() const;
 
 
-    /// @brief Use this method to create a topic in a forum supergroup chat.
-    /// The bot must be an administrator in the chat for this to work and must have the canManageTopics administrator rights.
+    /// @brief Use this method to create a topic in a forum supergroup chat or a private chat with a user.
+    /// In the case of a supergroup chat the bot must be an administrator in the chat for this to work and
+    // must have the can_manage_topics administrator right.
     /// https://core.telegram.org/bots/api#forumtopic
     /// @param chatId Integer or String Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
     /// @param name Topic name, 1-128 characters
@@ -1705,6 +1718,19 @@ namespace tgbotxx {
     /// @throws Exception on failure
     /// @ref https://core.telegram.org/bots/api#getmyshortdescription
     Ptr<BotShortDescription> getMyShortDescription(const std::string& languageCode = "") const;
+
+    /// @brief Changes the profile photo of the bot.
+    /// @param photo The new profile photo to set
+    /// @returns True on success.
+    /// @throws Exception on failure
+    /// @ref https://core.telegram.org/bots/api#setmyprofilephoto
+    bool setMyProfilePhoto(const Ptr<InputProfilePhoto>& photo) const;
+
+    /// @brief Removes the profile photo of the bot. Requires no parameters.
+    /// @returns True on success.
+    /// @throws Exception on failure
+    /// @ref https://core.telegram.org/bots/api#removemyprofilephoto
+    bool removeMyProfilePhoto() const;
 
     /// @brief Use this method to change the bot's menu button in a private chat, or the default menu button.
     /// @param chatId Optional. Unique identifier for the target private chat. If not specified, default bot's menu button will be changed

--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -922,6 +922,22 @@ namespace tgbotxx {
                           const Ptr<ReplyParameters>& replyParameters = nullptr) const;
 
 
+    /// @brief Use this method to stream a partial message to a user while the message is being generated. Returns True on success.
+    /// @param chatId Unique identifier for the target private chat
+    /// @param draftId Unique identifier of the message draft; must be non-zero. Changes of drafts with the same identifier are animated
+    /// @param text Text of the message to be sent, 1-4096 characters after entities parsing
+    /// @param messageThreadId Optional. Unique identifier for the target message thread
+    /// @param parseMode Optional. Mode for parsing entities in the message text. See https://core.telegram.org/bots/api#formatting-options for more details.
+    /// @param entities Optional. List of special entities that appear in message text, which can be specified instead of parseMode
+    /// @returns True on success
+    bool sendMessageDraft(std::int64_t chatId,
+                          std::int64_t draftId,
+                          const std::string& text,
+                          std::int32_t messageThreadId = 0,
+                          const std::string& parseMode = "",
+                          const std::vector<Ptr<MessageEntity>>& entities = std::vector<Ptr<MessageEntity>>()) const;
+
+
     /// @brief Use this method when you need to tell the user that something is happening on the bot's side.
     /// The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status).
     /// @param chatId Integer or String Unique identifier for the target chat or username of the target channel (in the format \@channelusername)

--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -1111,6 +1111,7 @@ namespace tgbotxx {
     /// @param canDeleteStories Optional. Pass True if the administrator can delete stories posted by other users; channels only
     /// @param canManageTopics Optional. Pass True if the user is allowed to create, rename, close, and reopen forum topics, supergroups only
     /// @param canManageDirectMessages Optional. Pass True if the administrator can manage direct messages within the channel and decline suggested posts; for channels only
+    /// @param canManageTags Optional. Pass True if the administrator can edit the tags of regular members; for groups and supergroups only
     /// @returns True on success.
     /// @throws Exception on failure
     /// @ref https://core.telegram.org/bots/api#promotechatmember
@@ -1131,7 +1132,8 @@ namespace tgbotxx {
                            bool canEditStories = false,
                            bool canDeleteStories = false,
                            bool canManageTopics = false,
-                           bool canManageDirectMessages = false) const;
+                           bool canManageDirectMessages = false,
+                           bool canManageTags = false) const;
 
 
     /// @brief Use this method to set a custom title for an administrator in a supergroup promoted by the bot.
@@ -1635,7 +1637,7 @@ namespace tgbotxx {
     /// @returns a UserChatBoosts object.
     /// @ref https://core.telegram.org/bots/api#getuserchatboosts
     Ptr<UserChatBoosts> getUserChatBoosts(const std::variant<std::int64_t, std::string>& chatId,
-                                      std::int64_t userId) const;
+                                          std::int64_t userId) const;
 
     /// @brief Use this method to change the list of the bot's commands.
     /// See this manual for more details about bot commands. https://core.telegram.org/bots/features#commands
@@ -1762,6 +1764,18 @@ namespace tgbotxx {
     /// @throws Exception on failure
     /// @ref https://core.telegram.org/bots/api#getmydefaultadministratorrights
     Ptr<ChatAdministratorRights> getMyDefaultAdministratorRights(bool forChannels = false) const;
+
+    /// @brief Use this method to get the current default administrator rights of the bot
+    /// @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+    /// @param userId Unique identifier of the target user
+    /// @param tag Optional. New tag for the member; 0-16 characters, emoji are not allowed
+    /// @returns True on success.
+    /// @throws Exception on failure
+    /// @ref https://core.telegram.org/bots/api#setchatmembertag
+    bool setChatMemberTag(const std::variant<std::int64_t, std::string>& chatId,
+                          std::int64_t userId,
+                          const std::string& tag = "") const;
+
 
   public: // Gifts
     /// @brief Returns the list of gifts that can be sent by the bot to users and channel chats. Requires no parameters.
@@ -2100,11 +2114,11 @@ namespace tgbotxx {
     /// @returns Story on success.
     /// @ref https://core.telegram.org/bots/api#repoststory
     Ptr<Story> repostStory(const std::string& businessConnectionId,
-                          std::int64_t fromChatId,
-                          std::int32_t fromStoryId,
-                          std::time_t activePeriod,
-                          bool postToChatPage = false,
-                          bool protectContent = false) const;
+                           std::int64_t fromChatId,
+                           std::int32_t fromStoryId,
+                           std::time_t activePeriod,
+                           bool postToChatPage = false,
+                           bool protectContent = false) const;
 
     /// @brief Edits a story previously posted by the bot on behalf of a managed business account. Requires the can_manage_stories business bot right.
     /// @param businessConnectionId Unique identifier of the business connection

--- a/include/tgbotxx/Api.hpp
+++ b/include/tgbotxx/Api.hpp
@@ -138,7 +138,7 @@ namespace tgbotxx {
     /// @brief Use this method to send text messages. On success, the sent Message is returned.
     /// @param chatId Integer or String Unique identifier for the target chat or username of the target channel (in the format @channelusername)
     /// @param text Text of the message to be sent, 1-4096 characters after entities parsing
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param parseMode Optional. Mode for parsing entities in the message text. See formatting options for more details. https://core.telegram.org/bots/api#formatting-options
     /// @param entities Optional. A JSON-serialized list of special entities that appear in message text, which can be specified instead of parseMode
     /// @param disableNotification Optional. Sends the message silently. Users will receive a notification with no sound.
@@ -179,7 +179,7 @@ namespace tgbotxx {
     /// @param chatId Integer or String. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
     /// @param fromChatId Integer or String. Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
     /// @param messageId Message identifier in the chat specified in fromChatId
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param disableNotification Optional. Sends the message silently. Users will receive a notification with no sound.
     /// @param protectContent Optional. Protects the contents of the forwarded message from forwarding and saving
     /// @param directMessagesTopicId Optional. Identifier of the direct messages topic to which the message will be forwarded; required if the message is forwarded to a direct messages chat
@@ -207,7 +207,7 @@ namespace tgbotxx {
     /// @param chatId Integer or String. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
     /// @param fromChatId Integer or String. Unique identifier for the chat where the original messages were sent (or channel username in the format @channelusername)
     /// @param messageIds A list of 1-100 identifiers of messages in the chat fromChatId to forward.    ///                   The identifiers must be specified in a strictly increasing order.
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param disableNotification Optional. Sends the messages silently. Users will receive a notification with no sound.
     /// @param protectContent Optional. Protects the contents of the forwarded messages from forwarding and saving
     /// @param directMessagesTopicId Optional. Identifier of the direct messages topic to which the messages will be forwarded;
@@ -232,7 +232,7 @@ namespace tgbotxx {
     /// @param chatId Integer or String. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
     /// @param fromChatId Integer or String. Identifier for the chat where the original message was sent (or channel username in the format @channelusername)
     /// @param messageId Message identifier in the chat specified in fromChatId
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param caption Optional. New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept
     /// @param parseMode Optional. Mode for parsing entities in the new caption. See formatting options for more details. https://core.telegram.org/bots/api#formatting-options
     /// @param captionEntities Optional. A JSON-serialized list of special entities that appear in the new caption, which can be specified instead of parseMode
@@ -275,7 +275,7 @@ namespace tgbotxx {
     /// @param fromChatId Integer or String. Unique identifier for the chat where the original messages were sent (or channel username in the format @channelusername)
     /// @param messageIds A list of 1-100 identifiers of messages in the chat fromChatId to copy.
     ///                   The identifiers must be specified in a strictly increasing order.
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param directMessagesTopicId Optional. Identifier of the direct messages topic to which the messages will be sent;
     ///                              required if the messages are sent to a direct messages chat
     /// @param disableNotification Optional. Sends the messages silently. Users will receive a notification with no sound.
@@ -302,7 +302,7 @@ namespace tgbotxx {
     ///              The photo must be at most 10 MB in size. The photo's width and height must not exceed 10000 in total.
     ///              Width and height ratio must be at most 20.
     ///              More information on Sending Files » https://core.telegram.org/bots/api#sending-files
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param caption Optional. Photo caption (may also be used when resending photos by file_id), 0-1024 characters after entities parsing
     /// @param parseMode Optional. Mode for parsing entities in the photo caption. See formatting options for more details. https://core.telegram.org/bots/api#formatting-options
     /// @param captionEntities Optional. A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parseMode
@@ -349,7 +349,7 @@ namespace tgbotxx {
     ///              Pass an HTTP URL as a String for Telegram to get an audio file from the Internet,
     ///              or upload a new one using multipart/form-data.
     ///              More information on Sending Files » https://core.telegram.org/bots/api#sending-files
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param caption Optional. Audio caption, 0-1024 characters after entities parsing
     /// @param parseMode Optional. Mode for parsing entities in the audio caption. See formatting options for more details. https://core.telegram.org/bots/api#formatting-options
     /// @param captionEntities Optional. A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parseMode
@@ -400,7 +400,7 @@ namespace tgbotxx {
     ///                 Pass a file_id as String to send a file that exists on the Telegram servers (recommended),
     ///                 Pass an HTTP URL as a String for Telegram to get a file from the Internet,
     ///                 or upload a new one using multipart/form-data. More information on Sending Files » https://core.telegram.org/bots/api#sending-files
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param thumbnail Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
     ///                  The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320.
     ///                  Ignored if the file is not uploaded using multipart/form-data.
@@ -448,7 +448,7 @@ namespace tgbotxx {
     ///              Pass a file_id as String to send a video that exists on the Telegram servers (recommended),
     ///              Pass an HTTP URL as a String for Telegram to get a video from the Internet,
     ///              or upload a new one using multipart/form-data. More information on Sending Files » https://core.telegram.org/bots/api#sending-files
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param duration Optional. Duration of sent video in seconds
     /// @param width Optional. Video width
     /// @param height Optional. Video height
@@ -511,7 +511,7 @@ namespace tgbotxx {
     ///                  Pass a file_id as String to send an animation that exists on the Telegram servers (recommended),
     ///                  Pass an HTTP URL as a String for Telegram to get an animation from the Internet,
     ///                  or upload a new one using multipart/form-data. More information on Sending Files » https://core.telegram.org/bots/api#sending-files
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param duration Optional. Duration of sent animation in seconds
     /// @param width Optional. Animation width
     /// @param height Optional. Animation height
@@ -562,7 +562,7 @@ namespace tgbotxx {
     ///              Pass a file_id as String to send a voice message that exists on the Telegram servers (recommended),
     ///              Pass an HTTP URL as a String for Telegram to get a voice message from the Internet,
     ///              or upload a new one using multipart/form-data. More information on Sending Files » https://core.telegram.org/bots/api#sending-files
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param caption Optional. Voice message caption, 0-1024 characters after entities parsing
     /// @param parseMode Optional. Mode for parsing entities in the caption. See formatting options for more details. https://core.telegram.org/bots/api#formatting-options
     /// @param captionEntities Optional. A JSON-serialized list of special entities that appear in the new caption, which can be specified instead of parseMode
@@ -604,7 +604,7 @@ namespace tgbotxx {
     ///                  Pass a file_id as String to send a video note that exists on the Telegram servers (recommended),
     ///                  Pass an HTTP URL as a String for Telegram to get a video note from the Internet,
     ///                  or upload a new one using multipart/form-data. More information on Sending Files » https://core.telegram.org/bots/api#sending-files
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param duration Optional. Duration of sent video in seconds
     /// @param length Optional. Video width and height (diameter) for the video note
     /// @param thumbnail Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
@@ -646,7 +646,7 @@ namespace tgbotxx {
     /// @param starCount The number of Telegram Stars that must be paid to buy access to the media; 1-10000
     /// @param media A JSON-serialized array describing the media to be sent; up to 10 items
     /// @param payload Bot-defined paid media payload, 0-128 bytes. This will not be displayed to the user, use it for your internal processes.
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param caption Optional. Media caption, 0-1024 characters after entities parsing
     /// @param parseMode Optional. Mode for parsing entities in the message text. See https://core.telegram.org/bots/api#formatting-options for more details.
     /// @param captionEntities Optional. A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
@@ -683,7 +683,7 @@ namespace tgbotxx {
     /// @brief Use this method to send a group of photos, videos, or documents as an album. On success, an array of the sent Messages is returned.
     /// @param chatId Integer or String. Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
     /// @param media Array of InputMedia objects. A JSON-serialized list of 2–10 items, each describing a photo, video, or document to be sent
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param disableNotification Optional. Sends the messages silently. Users will receive a notification with no sound.
     /// @param protectContent Optional. Protects the contents of the sent messages from forwarding and saving
     /// @param businessConnectionId Optional. Unique identifier of the business connection on behalf of which the messages will be sent
@@ -710,7 +710,7 @@ namespace tgbotxx {
     /// @param chatId Integer or String. Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
     /// @param latitude Latitude of the location
     /// @param longitude Longitude of the location
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param horizontalAccuracy Optional. The radius of uncertainty for the location, measured in meters; 0-1500
     /// @param livePeriod Optional. Period in seconds during which the location will be updated; should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely
     /// @param heading Optional. For live locations, a direction in which the user is moving, in degrees; must be between 1 and 360 if specified
@@ -750,7 +750,7 @@ namespace tgbotxx {
     /// @param longitude Longitude of the venue
     /// @param title Name of the venue
     /// @param address Address of the venue
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param foursquareId Optional. Foursquare identifier of the venue
     /// @param foursquareType Optional. Foursquare type of the venue, if known
     /// @param googlePlaceId Optional. Google Places identifier of the venue
@@ -792,7 +792,7 @@ namespace tgbotxx {
     /// @param firstName Contact's first name
     /// @param lastName Optional. Contact's last name
     /// @param vcard Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param disableNotification Optional. Sends the message silently
     /// @param protectContent Optional. Protects the contents of the sent message from forwarding and saving
     /// @param replyMarkup Optional. Additional interface options. One of InlineKeyboardMarkup or ReplyKeyboardMarkup or ReplyKeyboardRemove or ForceReply
@@ -823,7 +823,7 @@ namespace tgbotxx {
     /// @param chatId Integer or String. Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
     /// @param question Poll question, 1-300 characters
     /// @param options A JSON-serialized list of 2-12 answer options
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param questionParseMode Optional. Mode for parsing entities in the question. Currently, only custom emoji entities are allowed
     /// @param questionEntities Optional. A JSON-serialized list of special entities that appear in the poll question. Can be specified instead of questionParseMode
     /// @param isAnonymous Optional. True, if the poll needs to be anonymous, defaults to True
@@ -896,7 +896,7 @@ namespace tgbotxx {
     /// Dice can have values 1-6 for “🎲”, “🎯” and “🎳”,
     /// values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”.
     /// Defaults to “🎲”
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param disableNotification Optional. Sends the message silently
     /// @param protectContent Optional. Protects the contents of the sent message from forwarding
     /// @param replyMarkup Optional. Additional interface options. One of InlineKeyboardMarkup or ReplyKeyboardMarkup or ReplyKeyboardRemove or ForceReply
@@ -951,7 +951,7 @@ namespace tgbotxx {
     /// - "find_location" for location data
     /// - "record_video_note"
     /// - "upload_video_note" for video notes
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread or topic of a forum; for supergroups and private chats of bots with forum topic mode enabled only
     /// @param businessConnectionId Optional. Unique identifier of the business connection on behalf of which the message will be sent
     /// @returns True on success.
     /// @throws Exception on failure
@@ -1472,7 +1472,7 @@ namespace tgbotxx {
     /// The bot must be an administrator in the chat for this to work and must have the canManageTopics administrator rights.
     /// https://core.telegram.org/bots/api#forumtopic
     /// @param chatId Integer or String Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
-    /// @param messageThreadId Unique identifier for the target message thread of the forum topic
+    /// @param messageThreadId Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param name Optional. New topic name, 0-128 characters. If not specified or empty, the current name of the topic will be kept
     /// @param iconCustomEmojiId Optional. New unique identifier of the custom emoji shown as the topic icon.
     /// Use getForumTopicIconStickers to get all allowed custom emoji identifiers.
@@ -1491,7 +1491,7 @@ namespace tgbotxx {
     /// The bot must be an administrator in the chat for this to work and must have the canManageTopics administrator rights.
     /// https://core.telegram.org/bots/api#forumtopic
     /// @param chatId Integer or String Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
-    /// @param messageThreadId Unique identifier for the target message thread of the forum topic
+    /// @param messageThreadId Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @returns True on success.
     /// @throws Exception on failure
     /// @relatesalso createForumTopic editForumTopic reopenForumTopic deleteForumTopic
@@ -1503,7 +1503,7 @@ namespace tgbotxx {
     /// The bot must be an administrator in the chat for this to work and must have the canManageTopics administrator rights.
     /// https://core.telegram.org/bots/api#forumtopic
     /// @param chatId Integer or String Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
-    /// @param messageThreadId Unique identifier for the target message thread of the forum topic
+    /// @param messageThreadId Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @returns True on success.
     /// @throws Exception on failure
     /// @relatesalso createForumTopic editForumTopic closeForumTopic deleteForumTopic
@@ -1515,7 +1515,7 @@ namespace tgbotxx {
     /// The bot must be an administrator in the chat for this to work and must have the canManageTopics administrator rights.
     /// https://core.telegram.org/bots/api#forumtopic
     /// @param chatId Integer or String Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
-    /// @param messageThreadId Unique identifier for the target message thread of the forum topic
+    /// @param messageThreadId Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @returns True on success.
     /// @throws Exception on failure
     /// @relatesalso createForumTopic editForumTopic closeForumTopic reopenForumTopic
@@ -1526,7 +1526,7 @@ namespace tgbotxx {
     /// @brief Use this method to clear the list of pinned messages in a forum topic.
     /// The bot must be an administrator in the chat for this to work and must have the canPinMessages administrator right in the supergroup.
     /// @param chatId Integer or String Unique identifier for the target chat or username of the target channel (in the format \@channelusername)
-    /// @param messageThreadId Unique identifier for the target message thread of the forum topic
+    /// @param messageThreadId Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @returns True on success.
     /// @throws Exception on failure
     /// @relatesalso createForumTopic editForumTopic closeForumTopic reopenForumTopic deleteForumTopic
@@ -2039,7 +2039,7 @@ namespace tgbotxx {
     /// @param currency Three-letter ISO 4217 currency code, [see more on currencies](https://core.telegram.org/bots/payments#supported-currencies)
     /// @param prices Array of LabeledPrice, Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
     /// @param providerToken Optional. Payment provider token, obtained via @BotFather. Pass an empty string for payments in Telegram Stars.
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param maxTipAmount Optional. The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double).
     /// For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json,
     /// it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0
@@ -2498,7 +2498,7 @@ namespace tgbotxx {
     /// - Pass a file_id std::string to send a file that exists on the Telegram servers (recommended),
     /// - Pass an HTTP URL as an std::string for Telegram to get a .WEBP sticker from the Internet, or
     /// - Pass a cpr::File to upload a new .WEBP or .TGS sticker
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param emoji Optional. Emoji associated with the sticker; only for just uploaded stickers
     /// @param disableNotification Optional. Sends the message silently. Users will receive a notification with no sound.
     /// @param protectContent Optional. Protects the contents of the sent message from forwarding and saving
@@ -2712,7 +2712,7 @@ namespace tgbotxx {
     /// @brief Use this method to send a game.
     /// @param chatId Unique identifier for the target chat
     /// @param gameShortName Short name of the game, serves as the unique identifier for the game. Set up your games via @BotFather.
-    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    /// @param messageThreadId Optional. Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
     /// @param disableNotification Optional. Sends the message silently. Users will receive a notification with no sound.
     /// @param protectContent Optional. Protects the contents of the sent message from forwarding and saving
     /// @param replyParameters Optional. Description of the message to reply to

--- a/include/tgbotxx/objects/AcceptedGiftTypes.hpp
+++ b/include/tgbotxx/objects/AcceptedGiftTypes.hpp
@@ -23,6 +23,10 @@ namespace tgbotxx {
     /// @brief True, if a Telegram Premium subscription is accepted
     bool premiumSubscription{};
 
+    /// @brief True, if transfers of unique gifts from channels are accepted
+    bool giftsFromChannels{};
+
+
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object
     nl::json toJson() const {
@@ -31,6 +35,7 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD(json, "limited_gifts", limitedGifts);
       OBJECT_SERIALIZE_FIELD(json, "unique_gifts", uniqueGifts);
       OBJECT_SERIALIZE_FIELD(json, "premium_subscription", premiumSubscription);
+      OBJECT_SERIALIZE_FIELD(json, "gifts_from_channels", giftsFromChannels);
       return json;
     }
 
@@ -40,6 +45,7 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD(json, "limited_gifts", limitedGifts, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "unique_gifts", uniqueGifts, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "premium_subscription", premiumSubscription, false, false);
+      OBJECT_DESERIALIZE_FIELD(json, "gifts_from_channels", giftsFromChannels, false, false);
     }
   };
 

--- a/include/tgbotxx/objects/ChatAdministratorRights.hpp
+++ b/include/tgbotxx/objects/ChatAdministratorRights.hpp
@@ -61,6 +61,9 @@ namespace tgbotxx {
     /// @brief Optional. True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only
     bool canManageDirectMessages{};
 
+    /// @brief Optional. True, if the administrator can edit the tags of regular members; for groups and supergroups only. If omitted defaults to the value of can_pin_messages.
+    bool canManageTags{};
+
 
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object
@@ -82,6 +85,7 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD(json, "can_delete_stories", canDeleteStories);
       OBJECT_SERIALIZE_FIELD(json, "can_manage_topics", canManageTopics);
       OBJECT_SERIALIZE_FIELD(json, "can_manage_direct_messages", canManageDirectMessages);
+      OBJECT_SERIALIZE_FIELD(json, "can_manage_tags", canManageTags);
       return json;
     }
 
@@ -103,6 +107,7 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD(json, "can_delete_stories", canDeleteStories, false, true);
       OBJECT_DESERIALIZE_FIELD(json, "can_manage_topics", canManageTopics, false, true);
       OBJECT_DESERIALIZE_FIELD(json, "can_manage_direct_messages", canManageDirectMessages, false, true);
+      OBJECT_DESERIALIZE_FIELD(json, "can_manage_tags", canManageTags, false, true);
     }
   };
 }

--- a/include/tgbotxx/objects/ChatFullInfo.hpp
+++ b/include/tgbotxx/objects/ChatFullInfo.hpp
@@ -10,6 +10,9 @@
 #include <tgbotxx/objects/BusinessIntro.hpp>
 #include <tgbotxx/objects/BusinessLocation.hpp>
 #include <tgbotxx/objects/BusinessOpeningHours.hpp>
+#include <tgbotxx/objects/UserRating.hpp>
+#include <tgbotxx/objects/Audio.hpp>
+#include <tgbotxx/objects/UniqueGiftColors.hpp>
 
 namespace tgbotxx {
   /// @brief This object represents a chat.
@@ -134,6 +137,18 @@ namespace tgbotxx {
 
     /// @brief Optional. For supergroups, the location to which the supergroup is connected.
     Ptr<ChatLocation> location;
+
+    /// @brief Optional. For private chats, the rating of the user if any
+    Ptr<UserRating> rating;
+
+    /// @brief Optional. For private chats, the first audio added to the profile of the user
+    Ptr<Audio> firstProfileAudio;
+
+    /// @brief Optional. The color scheme based on a unique gift that must be used for the chat's name, message replies and link previews
+    Ptr<UniqueGiftColors> uniqueGiftColors;
+
+    /// @brief Optional. The color scheme based on a unique gift that must be used for the chat's name, message replies and link previews
+    std::int64_t paidMessageStarCount{};
 
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object

--- a/include/tgbotxx/objects/ChatMember.hpp
+++ b/include/tgbotxx/objects/ChatMember.hpp
@@ -135,6 +135,12 @@ namespace tgbotxx {
     /// @brief Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only
     bool canManageTopics{};
 
+    /// @brief Optional. True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only
+    bool canManageDirectMessages{};
+
+    /// @brief Optional. True, if the administrator can edit the tags of regular members; for groups and supergroups only. If omitted defaults to the value of can_pin_messages.
+    bool canManageTags{};
+
     /// @brief Optional. Custom title for this user
     std::string customTitle;
 
@@ -159,6 +165,8 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD(json, "can_edit_stories", canEditStories);
       OBJECT_SERIALIZE_FIELD(json, "can_delete_stories", canDeleteStories);
       OBJECT_SERIALIZE_FIELD(json, "can_manage_topics", canManageTopics);
+      OBJECT_SERIALIZE_FIELD(json, "can_manage_direct_messages", canManageDirectMessages);
+      OBJECT_SERIALIZE_FIELD(json, "can_manage_tags", canManageTags);
       OBJECT_SERIALIZE_FIELD(json, "custom_title", customTitle);
       return json;
     }
@@ -182,6 +190,8 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD(json, "can_edit_stories", canEditStories, false, true);
       OBJECT_DESERIALIZE_FIELD(json, "can_delete_stories", canDeleteStories, false, true);
       OBJECT_DESERIALIZE_FIELD(json, "can_manage_topics", canManageTopics, false, true);
+      OBJECT_DESERIALIZE_FIELD(json, "can_manage_direct_messages", canManageDirectMessages, false, true);
+      OBJECT_DESERIALIZE_FIELD(json, "can_manage_tags", canManageTags, false, true);
       OBJECT_DESERIALIZE_FIELD(json, "custom_title", customTitle, "", true);
     }
   };
@@ -197,16 +207,26 @@ namespace tgbotxx {
       ChatMemberMember::fromJson(json);
     }
 
+    /// @brief Optional. Tag of the member
+    std::string tag;
+
+    /// @brief Optional. Date when the user's subscription will expire; Unix time
+    std::time_t untilDate{};
+
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object
     [[nodiscard]] nl::json toJson() const override {
       nl::json json = ChatMember::toJson();
+      OBJECT_SERIALIZE_FIELD(json, "tag", tag);
+      OBJECT_SERIALIZE_FIELD(json, "until_date", untilDate);
       return json;
     }
 
     /// @brief Deserializes this object from JSON
     void fromJson(const nl::json& json) override {
       ChatMember::fromJson(json);
+      OBJECT_DESERIALIZE_FIELD(json, "tag", tag, "", true);
+      OBJECT_DESERIALIZE_FIELD(json, "until_date", untilDate, 0, true);
     }
   };
 
@@ -220,6 +240,9 @@ namespace tgbotxx {
     explicit ChatMemberRestricted(const nl::json& json) {
       ChatMemberRestricted::fromJson(json);
     }
+
+    /// @brief Optional. Tag of the member
+    std::string tag;
 
     /// @brief True, if the user is a member of the chat at the moment of the request
     bool isMember{};
@@ -254,6 +277,9 @@ namespace tgbotxx {
     /// @brief True, if the user is allowed to add web page previews to their messages
     bool canAddWebPagePreviews{};
 
+    /// @brief True, if the user is allowed to edit their own tag
+    bool canEditTag{};
+
     /// @brief True, if the user is allowed to change the chat title, photo and other settings
     bool canChangeInfo{};
 
@@ -274,6 +300,7 @@ namespace tgbotxx {
     /// @returns JSON representation of this object
     [[nodiscard]] nl::json toJson() const override {
       nl::json json = ChatMember::toJson();
+      OBJECT_SERIALIZE_FIELD(json, "tag", tag);
       OBJECT_SERIALIZE_FIELD(json, "is_member", isMember);
       OBJECT_SERIALIZE_FIELD(json, "can_send_messages", canSendMessages);
       OBJECT_SERIALIZE_FIELD(json, "can_send_audios", canSendAudios);
@@ -285,6 +312,7 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD(json, "can_send_polls", canSendPolls);
       OBJECT_SERIALIZE_FIELD(json, "can_send_other_messages", canSendOtherMessages);
       OBJECT_SERIALIZE_FIELD(json, "can_add_web_page_previews", canAddWebPagePreviews);
+      OBJECT_SERIALIZE_FIELD(json, "can_edit_tag", canEditTag);
       OBJECT_SERIALIZE_FIELD(json, "can_change_info", canChangeInfo);
       OBJECT_SERIALIZE_FIELD(json, "can_invite_users", canInviteUsers);
       OBJECT_SERIALIZE_FIELD(json, "can_pin_messages", canPinMessages);
@@ -296,6 +324,7 @@ namespace tgbotxx {
     /// @brief Deserializes this object from JSON
     void fromJson(const nl::json& json) override {
       ChatMember::fromJson(json);
+      OBJECT_DESERIALIZE_FIELD(json, "tag", tag, "", true);
       OBJECT_DESERIALIZE_FIELD(json, "is_member", isMember, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "can_send_messages", canSendMessages, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "can_send_audios", canSendAudios, false, false);
@@ -307,6 +336,7 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD(json, "can_send_polls", canSendPolls, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "can_send_other_messages", canSendOtherMessages, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "can_add_web_page_previews", canAddWebPagePreviews, false, false);
+      OBJECT_DESERIALIZE_FIELD(json, "can_edit_tag", canEditTag, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "can_change_info", canChangeInfo, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "can_invite_users", canInviteUsers, false, false);
       OBJECT_DESERIALIZE_FIELD(json, "can_pin_messages", canPinMessages, false, false);

--- a/include/tgbotxx/objects/ChatOwnerChanged.hpp
+++ b/include/tgbotxx/objects/ChatOwnerChanged.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <tgbotxx/objects/Object.hpp>
+#include <tgbotxx/objects/User.hpp>
+
+namespace tgbotxx {
+  /// @brief Describes a service message about an ownership change in the chat.
+  /// @ref https://core.telegram.org/bots/api#chatownerchanged
+  struct ChatOwnerChanged {
+    ChatOwnerChanged() = default;
+    explicit ChatOwnerChanged(const nl::json& json) {
+      fromJson(json);
+    }
+
+    /// @brief The new owner of the chat
+    Ptr<User> newOwner;
+
+
+    /// @brief Serializes this object to JSON
+    /// @returns JSON representation of this object
+    nl::json toJson() const {
+      nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD_PTR(json, "new_owner", newOwner);
+      return json;
+    }
+
+    /// @brief Deserializes this object from JSON
+    void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD_PTR(json, "new_owner", newOwner, false);
+    }
+  };
+}

--- a/include/tgbotxx/objects/ChatOwnerLeft.hpp
+++ b/include/tgbotxx/objects/ChatOwnerLeft.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <tgbotxx/objects/Object.hpp>
+#include <tgbotxx/objects/User.hpp>
+
+namespace tgbotxx {
+  /// @brief Describes a service message about the chat owner leaving the chat.
+  /// @ref https://core.telegram.org/bots/api#chatownerleft
+  struct ChatOwnerLeft {
+    ChatOwnerLeft() = default;
+    explicit ChatOwnerLeft(const nl::json& json) {
+      fromJson(json);
+    }
+
+    /// @brief Optional. The user which will be the new owner of the chat if the previous owner does not return to the chat
+    Ptr<User> newOwner;
+
+
+    /// @brief Serializes this object to JSON
+    /// @returns JSON representation of this object
+    nl::json toJson() const {
+      nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD_PTR(json, "new_owner", newOwner);
+      return json;
+    }
+
+    /// @brief Deserializes this object from JSON
+    void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD_PTR(json, "new_owner", newOwner, true);
+    }
+  };
+}

--- a/include/tgbotxx/objects/ChatPermissions.hpp
+++ b/include/tgbotxx/objects/ChatPermissions.hpp
@@ -40,6 +40,9 @@ namespace tgbotxx {
       /// @brief Optional. True, if the user is allowed to add web page previews to their messages
       bool canAddWebPagePreviews{};
 
+      /// @brief Optional. True, if the user is allowed to edit their own tag
+      bool canEditTag{};
+
       /// @brief Optional. True, if the user is allowed to change the chat title, photo and other settings. Ignored in public supergroups
       bool canChangeInfo{};
 
@@ -67,6 +70,7 @@ namespace tgbotxx {
         OBJECT_SERIALIZE_FIELD(json, "can_send_polls", canSendPolls);
         OBJECT_SERIALIZE_FIELD(json, "can_send_other_messages", canSendOtherMessages);
         OBJECT_SERIALIZE_FIELD(json, "can_add_web_page_previews", canAddWebPagePreviews);
+        OBJECT_SERIALIZE_FIELD(json, "can_edit_tag", canEditTag);
         OBJECT_SERIALIZE_FIELD(json, "can_change_info", canChangeInfo);
         OBJECT_SERIALIZE_FIELD(json, "can_invite_users", canInviteUsers);
         OBJECT_SERIALIZE_FIELD(json, "can_pin_messages", canPinMessages);
@@ -86,6 +90,7 @@ namespace tgbotxx {
         OBJECT_DESERIALIZE_FIELD(json, "can_send_polls", canSendPolls, false, true);
         OBJECT_DESERIALIZE_FIELD(json, "can_send_other_messages", canSendOtherMessages, false, true);
         OBJECT_DESERIALIZE_FIELD(json, "can_add_web_page_previews", canAddWebPagePreviews, false, true);
+        OBJECT_DESERIALIZE_FIELD(json, "can_edit_tag", canEditTag, false, true);
         OBJECT_DESERIALIZE_FIELD(json, "can_change_info", canChangeInfo, false, true);
         OBJECT_DESERIALIZE_FIELD(json, "can_invite_users", canInviteUsers, false, true);
         OBJECT_DESERIALIZE_FIELD(json, "can_pin_messages", canPinMessages, false, true);

--- a/include/tgbotxx/objects/ChecklistTask.hpp
+++ b/include/tgbotxx/objects/ChecklistTask.hpp
@@ -2,6 +2,7 @@
 #include <tgbotxx/objects/Object.hpp>
 #include <tgbotxx/objects/MessageEntity.hpp>
 #include <tgbotxx/objects/User.hpp>
+#include <tgbotxx/objects/Chat.hpp>
 
 namespace tgbotxx {
   /// @brief Describes a task in a checklist.
@@ -24,6 +25,9 @@ namespace tgbotxx {
     /// @brief Optional. User that completed the task; omitted if the task wasn't completed
     Ptr<User> completedByUser;
 
+    /// @brief Optional. User that completed the task; omitted if the task wasn't completed
+    Ptr<Chat> completedByChat;
+
     /// @brief Optional. Point in time (Unix timestamp) when the task was completed; 0 if the task wasn't completed
     std::time_t completionDate{};
 
@@ -36,6 +40,7 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD(json, "text", text);
       OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, "text_entities", textEntities);
       OBJECT_SERIALIZE_FIELD_PTR(json, "completed_by_user", completedByUser);
+      OBJECT_SERIALIZE_FIELD_PTR(json, "completed_by_chat", completedByChat);
       OBJECT_SERIALIZE_FIELD(json, "completion_date", completionDate);
       return json;
     }
@@ -46,6 +51,7 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD(json, "text", text, "", false);
       OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, "text_entities", textEntities, true);
       OBJECT_DESERIALIZE_FIELD_PTR(json, "completed_by_user", completedByUser, true);
+      OBJECT_DESERIALIZE_FIELD_PTR(json, "completed_by_chat", completedByChat, true);
       OBJECT_DESERIALIZE_FIELD(json, "completion_date", completionDate, 0, true);
     }
   };

--- a/include/tgbotxx/objects/ForumTopic.hpp
+++ b/include/tgbotxx/objects/ForumTopic.hpp
@@ -22,6 +22,9 @@ namespace tgbotxx {
       /// @brief Optional. Unique identifier of the custom emoji shown as the topic icon
       std::string iconCustomEmojiId{};
 
+      /// @brief Optional. True, if the name of the topic wasn't specified explicitly by its creator and likely needs to be changed by the bot
+      bool isNameImplicit{};
+
       /// @brief Serializes this object to JSON
       /// @returns JSON representation of this object
       nl::json toJson() const {
@@ -30,6 +33,7 @@ namespace tgbotxx {
         OBJECT_SERIALIZE_FIELD(json, "name", name);
         OBJECT_SERIALIZE_FIELD(json, "icon_color", iconColor);
         OBJECT_SERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId);
+        OBJECT_SERIALIZE_FIELD(json, "is_name_implicit", isNameImplicit);
         return json;
       }
 
@@ -39,6 +43,7 @@ namespace tgbotxx {
         OBJECT_DESERIALIZE_FIELD(json, "name", name, "", false);
         OBJECT_DESERIALIZE_FIELD(json, "icon_color", iconColor, 0x000000, false);
         OBJECT_DESERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId, "", true);
+        OBJECT_DESERIALIZE_FIELD(json, "is_name_implicit", isNameImplicit, false, true);
       }
   };
 }

--- a/include/tgbotxx/objects/ForumTopicCreated.hpp
+++ b/include/tgbotxx/objects/ForumTopicCreated.hpp
@@ -5,36 +5,41 @@ namespace tgbotxx {
   /// @brief This object represents a service message about a new forum topic created in the chat.
   /// @ref https://core.telegram.org/bots/api#forumtopiccreated
   struct ForumTopicCreated {
-      ForumTopicCreated() = default;
-      explicit ForumTopicCreated(const nl::json& json) {
-        fromJson(json);
-      }
+    ForumTopicCreated() = default;
+    explicit ForumTopicCreated(const nl::json& json) {
+      fromJson(json);
+    }
 
-      /// @brief Name of the topic
-      std::string name;
+    /// @brief Name of the topic
+    std::string name;
 
-      /// @brief Color of the topic icon in RGB format
-      std::int32_t iconColor{};
+    /// @brief Color of the topic icon in RGB format
+    std::int32_t iconColor{};
 
-      /// @brief Optional. Unique identifier of the custom emoji shown as the topic icon
-      std::string iconCustomEmojiId;
+    /// @brief Optional. Unique identifier of the custom emoji shown as the topic icon
+    std::string iconCustomEmojiId;
+
+    /// @brief Optional. True, if the name of the topic wasn't specified explicitly by its creator and likely needs to be changed by the bot
+    bool isNameImplicit{};
 
 
-      /// @brief Serializes this object to JSON
-      /// @returns JSON representation of this object
-      nl::json toJson() const {
-        nl::json json = nl::json::object();
-        OBJECT_SERIALIZE_FIELD(json, "name", name);
-        OBJECT_SERIALIZE_FIELD(json, "icon_color", iconColor);
-        OBJECT_SERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId);
-        return json;
-      }
+    /// @brief Serializes this object to JSON
+    /// @returns JSON representation of this object
+    nl::json toJson() const {
+      nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD(json, "name", name);
+      OBJECT_SERIALIZE_FIELD(json, "icon_color", iconColor);
+      OBJECT_SERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId);
+      OBJECT_SERIALIZE_FIELD(json, "is_name_implicit", isNameImplicit);
+      return json;
+    }
 
-      /// @brief Deserializes this object from JSON
-      void fromJson(const nl::json& json) {
-        OBJECT_DESERIALIZE_FIELD(json, "name", name, "", false);
-        OBJECT_DESERIALIZE_FIELD(json, "icon_color", iconColor, 0, false);
-        OBJECT_DESERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId, "", true);
-      }
+    /// @brief Deserializes this object from JSON
+    void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD(json, "name", name, "", false);
+      OBJECT_DESERIALIZE_FIELD(json, "icon_color", iconColor, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId, "", true);
+      OBJECT_DESERIALIZE_FIELD(json, "is_name_implicit", isNameImplicit, false, true);
+    }
   };
 }

--- a/include/tgbotxx/objects/Gift.hpp
+++ b/include/tgbotxx/objects/Gift.hpp
@@ -2,6 +2,7 @@
 #include <tgbotxx/objects/Object.hpp>
 #include <tgbotxx/objects/Sticker.hpp>
 #include <tgbotxx/objects/Chat.hpp>
+#include <tgbotxx/objects/GiftBackground.hpp>
 
 namespace tgbotxx {
   /// @brief This object represents a gift that can be sent by the bot.
@@ -24,11 +25,29 @@ namespace tgbotxx {
     /// @brief Optional. The number of Telegram Stars that must be paid to upgrade the gift to a unique one
     std::int64_t upgradeStarCount{};
 
+    /// @brief Optional. True, if the gift can only be purchased by Telegram Premium subscribers
+    bool isPremium{};
+
+    /// @brief Optional. True, if the gift can be used (after being upgraded) to customize a user's appearance
+    bool hasColors{};
+
     /// @brief Optional. The total number of the gifts of this type that can be sent; for limited gifts only
     std::int64_t totalCount{};
 
     /// @brief Optional. The number of remaining gifts of this type that can be sent; for limited gifts only
     std::int64_t remainingCount{};
+
+    /// @brief Optional. The total number of gifts of this type that can be sent by the bot; for limited gifts only
+    std::int64_t personalTotalCount{};
+
+    /// @brief Optional. The number of remaining gifts of this type that can be sent by the bot; for limited gifts only
+    std::int64_t personalRemainingCount{};
+
+    /// @brief Optional. Information about the chat that published the gift
+    Ptr<GiftBackground> background;
+
+    /// @brief Optional. The total number of different unique gifts that can be obtained by upgrading the gift
+    std::int64_t uniqueGiftVariantCount{};
 
     /// @brief Optional. Information about the chat that published the gift
     Ptr<Chat> publisherChat;
@@ -41,9 +60,15 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD_PTR(json, "sticker", sticker);
       OBJECT_SERIALIZE_FIELD(json, "star_count", starCount);
       OBJECT_SERIALIZE_FIELD(json, "upgrade_star_count", upgradeStarCount);
+      OBJECT_SERIALIZE_FIELD(json, "is_premium", isPremium);
+      OBJECT_SERIALIZE_FIELD(json, "has_colors", hasColors);
       OBJECT_SERIALIZE_FIELD(json, "total_count", totalCount);
       OBJECT_SERIALIZE_FIELD(json, "remaining_count", remainingCount);
-      OBJECT_SERIALIZE_FIELD_PTR(json, "year", publisherChat);
+      OBJECT_SERIALIZE_FIELD(json, "personal_total_count", personalTotalCount);
+      OBJECT_SERIALIZE_FIELD(json, "personal_remaining_count", personalRemainingCount);
+      OBJECT_SERIALIZE_FIELD_PTR(json, "background", background);
+      OBJECT_SERIALIZE_FIELD(json, "unique_gift_variant_count", uniqueGiftVariantCount);
+      OBJECT_SERIALIZE_FIELD_PTR(json, "publisher_chat", publisherChat);
       return json;
     }
 
@@ -53,9 +78,15 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD_PTR(json, "sticker", sticker, false);
       OBJECT_DESERIALIZE_FIELD(json, "star_count", starCount, 0, false);
       OBJECT_DESERIALIZE_FIELD(json, "upgrade_star_count", upgradeStarCount, 0, true);
+      OBJECT_DESERIALIZE_FIELD(json, "is_premium", isPremium, false, true);
+      OBJECT_DESERIALIZE_FIELD(json, "has_colors", hasColors, false, true);
       OBJECT_DESERIALIZE_FIELD(json, "total_count", totalCount, 0, true);
       OBJECT_DESERIALIZE_FIELD(json, "remaining_count", remainingCount, 0, true);
-      OBJECT_DESERIALIZE_FIELD_PTR(json, "year", publisherChat, true);
+      OBJECT_DESERIALIZE_FIELD(json, "personal_total_count", personalTotalCount, 0, true);
+      OBJECT_DESERIALIZE_FIELD(json, "personal_remaining_count", personalRemainingCount, 0, true);
+      OBJECT_DESERIALIZE_FIELD_PTR(json, "background", background, true);
+      OBJECT_DESERIALIZE_FIELD(json, "unique_gift_variant_count", uniqueGiftVariantCount, 0, true);
+      OBJECT_DESERIALIZE_FIELD_PTR(json, "publisher_chat", publisherChat, true);
     }
   };
 }

--- a/include/tgbotxx/objects/GiftBackground.hpp
+++ b/include/tgbotxx/objects/GiftBackground.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <tgbotxx/objects/Object.hpp>
+
+namespace tgbotxx {
+  /// @brief This object describes the background of a gift.
+  /// @ref https://core.telegram.org/bots/api#giftbackground
+  struct GiftBackground {
+    GiftBackground() = default;
+    explicit GiftBackground(const nl::json& json) {
+      fromJson(json);
+    }
+
+    /// @brief Center color of the background in RGB format
+    std::int32_t centerColor{};
+
+    /// @brief Edge color of the background in RGB format
+    std::int32_t edgeColor{};
+
+    /// @brief Text color of the background in RGB format
+    std::int32_t textColor{};
+
+
+    /// @brief Serializes this object to JSON
+    /// @returns JSON representation of this object
+    nl::json toJson() const {
+      nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD(json, "center_color", centerColor);
+      OBJECT_SERIALIZE_FIELD(json, "edge_color", edgeColor);
+      OBJECT_SERIALIZE_FIELD(json, "text_color", textColor);
+      return json;
+    }
+
+    /// @brief Deserializes this object from JSON
+    void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD(json, "center_color", centerColor, 0x000000, false);
+      OBJECT_DESERIALIZE_FIELD(json, "edge_color", edgeColor, 0x000000, false);
+      OBJECT_DESERIALIZE_FIELD(json, "text_color", textColor, 0x000000, false);
+    }
+  };
+}

--- a/include/tgbotxx/objects/GiftInfo.hpp
+++ b/include/tgbotxx/objects/GiftInfo.hpp
@@ -25,6 +25,9 @@ namespace tgbotxx {
     /// @brief Optional. Number of Telegram Stars that were prepaid by the sender for the ability to upgrade the gift
     std::int64_t prepaidUpgradeStarCount{};
 
+    /// @brief Optional. True, if the gift's upgrade was purchased after the gift was sent
+    bool isUpgradeSeparate{};
+
     /// @brief Optional. True, if the gift can be upgraded to a unique gift
     bool canBeUpgraded{};
 
@@ -37,6 +40,9 @@ namespace tgbotxx {
     /// @brief Optional. True, if the sender and gift text are shown only to the gift receiver; otherwise, everyone will be able to see them
     bool isPrivate{};
 
+    /// @brief Optional. Unique number reserved for this gift when upgraded. See the number field in UniqueGift
+    std::int32_t uniqueGiftNumber{};
+
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object
     nl::json toJson() const {
@@ -45,10 +51,12 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD(json, "owned_gift_id", ownedGiftId);
       OBJECT_SERIALIZE_FIELD(json, "convert_star_count", convertStarCount);
       OBJECT_SERIALIZE_FIELD(json, "prepaid_upgrade_star_count", prepaidUpgradeStarCount);
+      OBJECT_SERIALIZE_FIELD(json, "is_upgrade_separate", isUpgradeSeparate);
       OBJECT_SERIALIZE_FIELD(json, "can_be_upgraded", canBeUpgraded);
       OBJECT_SERIALIZE_FIELD(json, "text", text);
       OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, "entities", entities);
       OBJECT_SERIALIZE_FIELD(json, "is_private", isPrivate);
+      OBJECT_SERIALIZE_FIELD(json, "unique_gift_number", uniqueGiftNumber);
       return json;
     }
 
@@ -58,10 +66,12 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD(json, "owned_gift_id", ownedGiftId, "", true);
       OBJECT_DESERIALIZE_FIELD(json, "convert_star_count", convertStarCount, 0, true);
       OBJECT_DESERIALIZE_FIELD(json, "prepaid_upgrade_star_count", prepaidUpgradeStarCount, 0, true);
+      OBJECT_DESERIALIZE_FIELD(json, "is_upgrade_separate", isUpgradeSeparate, false, true);
       OBJECT_DESERIALIZE_FIELD(json, "can_be_upgraded", canBeUpgraded, false, true);
       OBJECT_DESERIALIZE_FIELD(json, "text", text, "", true);
       OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, "entities", entities, true);
       OBJECT_DESERIALIZE_FIELD(json, "is_private", isPrivate, false, true);
+      OBJECT_DESERIALIZE_FIELD(json, "unique_gift_number", uniqueGiftNumber, 0, true);
     }
   };
 }

--- a/include/tgbotxx/objects/InlineKeyboardButton.hpp
+++ b/include/tgbotxx/objects/InlineKeyboardButton.hpp
@@ -19,6 +19,15 @@ namespace tgbotxx {
     /// @brief Label text on the button
     std::string text;
 
+    /// @brief Optional. Unique identifier of the custom emoji shown before the text of the button.
+    /// Can only be used by bots that purchased additional usernames on Fragment or in the messages directly sent by the bot to private,
+    /// group and supergroup chats if the owner of the bot has a Telegram Premium subscription.
+    std::string iconCustomEmojiId;
+
+    /// @brief Optional. Style of the button. Must be one of “danger” (red), “success” (green) or “primary” (blue).
+    /// If omitted, then an app-specific style is used.
+    std::string style;
+
     /// @brief Optional. HTTP or tg:// URL to be opened when the button is pressed.
     /// Links tg://user?id=<user_id> can be used to mention a user by their identifier without using a username,
     /// if this is allowed by their privacy settings.
@@ -69,6 +78,9 @@ namespace tgbotxx {
     nl::json toJson() const {
       nl::json json = nl::json::object();
       OBJECT_SERIALIZE_FIELD(json, "text", text);
+      if (not iconCustomEmojiId.empty()) // @todo: this is a workaround. Seems to be the only field that makes telegram complain if its empty "" ->  Bad Request: can't parse keyboard button: Field "icon_custom_emoji_id" must be a valid Number
+        OBJECT_SERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId);
+      OBJECT_SERIALIZE_FIELD(json, "style", style);
       OBJECT_SERIALIZE_FIELD(json, "url", url);
       OBJECT_SERIALIZE_FIELD(json, "callback_data", callbackData);
       OBJECT_SERIALIZE_FIELD_PTR(json, "web_app", webApp);
@@ -85,6 +97,8 @@ namespace tgbotxx {
     /// @brief Deserializes this object from JSON
     void fromJson(const nl::json& json) {
       OBJECT_DESERIALIZE_FIELD(json, "text", text, "", false);
+      OBJECT_DESERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId, "", true);
+      OBJECT_DESERIALIZE_FIELD(json, "style", style, "", true);
       OBJECT_DESERIALIZE_FIELD(json, "url", url, "", true);
       OBJECT_DESERIALIZE_FIELD(json, "callback_data", callbackData, "", true);
       OBJECT_DESERIALIZE_FIELD_PTR(json, "web_app", webApp, true);

--- a/include/tgbotxx/objects/KeyboardButton.hpp
+++ b/include/tgbotxx/objects/KeyboardButton.hpp
@@ -19,6 +19,15 @@ namespace tgbotxx {
       /// @brief Text of the button. If none of the optional fields are used, it will be sent as a message when the button is pressed
       std::string text;
 
+      /// @brief Optional. Unique identifier of the custom emoji shown before the text of the button.
+      /// Can only be used by bots that purchased additional usernames on Fragment or in the messages directly sent by the bot to private,
+      /// group and supergroup chats if the owner of the bot has a Telegram Premium subscription.
+      std::string iconCustomEmojiId;
+
+      /// @brief Optional. Style of the button. Must be one of “danger” (red), “success” (green) or “primary” (blue).
+      /// If omitted, then an app-specific style is used.
+      std::string style;
+
       /// @brief Optional. If specified, pressing the button will open a list of suitable users.
       /// Tapping on any user will send their identifier to the bot in a “user_shared” service message.
       /// @note Available in private chats only.
@@ -52,6 +61,9 @@ namespace tgbotxx {
       nl::json toJson() const {
         nl::json json = nl::json::object();
         OBJECT_SERIALIZE_FIELD(json, "text", text);
+        if (not iconCustomEmojiId.empty()) // @todo: this is a workaround. Seems to be the only field that makes telegram complain if its empty "" ->  Bad Request: can't parse keyboard button: Field "icon_custom_emoji_id" must be a valid Number
+          OBJECT_SERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId);
+        OBJECT_SERIALIZE_FIELD(json, "style", style);
         OBJECT_SERIALIZE_FIELD_PTR(json, "request_users", requestUsers);
         OBJECT_SERIALIZE_FIELD_PTR(json, "request_chat", requestChat);
         OBJECT_SERIALIZE_FIELD(json, "request_contact", requestContact);
@@ -64,6 +76,8 @@ namespace tgbotxx {
       /// @brief Deserializes this object from JSON
       void fromJson(const nl::json& json) {
         OBJECT_DESERIALIZE_FIELD(json, "text", text, "", false);
+        OBJECT_DESERIALIZE_FIELD(json, "icon_custom_emoji_id", iconCustomEmojiId, "", true);
+        OBJECT_DESERIALIZE_FIELD(json, "style", style, "", true);
         OBJECT_DESERIALIZE_FIELD_PTR(json, "request_users", requestUsers, true);
         OBJECT_DESERIALIZE_FIELD_PTR(json, "request_chat", requestChat, true);
         OBJECT_DESERIALIZE_FIELD(json, "request_contact", requestContact, false, true);

--- a/include/tgbotxx/objects/Message.hpp
+++ b/include/tgbotxx/objects/Message.hpp
@@ -66,6 +66,8 @@ namespace tgbotxx {
   struct SuggestedPostDeclined;
   struct SuggestedPostPaid;
   struct SuggestedPostRefunded;
+  struct ChatOwnerLeft;
+  struct ChatOwnerChanged;
 
   /// @brief This object represents a message.
   /// @ref https://core.telegram.org/bots/api#message
@@ -245,6 +247,12 @@ namespace tgbotxx {
 
       /// @brief Optional. A member was removed from the group, information about them (this member may be the bot itself)
       Ptr<User> leftChatMember;
+
+      /// @brief Optional. Service message: chat owner has left
+      Ptr<ChatOwnerLeft> chatOwnerLeft;
+
+      /// @brief Optional. Service message: chat owner has changed
+      Ptr<ChatOwnerChanged> chatOwnerChanged;
 
       /// @brief Optional. A chat title was changed to this value
       std::string newChatTitle;

--- a/include/tgbotxx/objects/Message.hpp
+++ b/include/tgbotxx/objects/Message.hpp
@@ -78,7 +78,7 @@ namespace tgbotxx {
       /// @brief Unique message identifier inside this chat
       std::int32_t messageId{};
 
-      /// @brief Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
+      /// @brief Optional. Unique identifier of a message thread or forum topic to which the message belongs; for supergroups and private chats only
       std::int32_t messageThreadId{};
 
       /// @brief Optional. Information about the direct messages chat topic that contains the message
@@ -114,7 +114,7 @@ namespace tgbotxx {
       /// @brief Optional. Information about the original message for forwarded messages
       Ptr<MessageOrigin> forwardOrigin;
 
-      /// @brief Optional. True, if the message is sent to a forum topic
+      /// @brief Optional. True, if the message is sent to a topic in a forum supergroup or a private chat with the bot
       bool isTopicMessage{};
 
       /// @brief Optional. True, if the message is a channel post that was automatically

--- a/include/tgbotxx/objects/Message.hpp
+++ b/include/tgbotxx/objects/Message.hpp
@@ -102,6 +102,9 @@ namespace tgbotxx {
       /// @brief Optional. The bot that actually sent the message on behalf of the business account. Available only for outgoing messages sent on behalf of the connected business account.
       Ptr<User> senderBusinessBot;
 
+      /// @brief Optional. Tag or custom title of the sender of the message; for supergroups only
+      std::string senderTag;
+
       /// @brief Date the message was sent in Unix time. It is always a positive number, representing a valid date.
       std::time_t date{};
 

--- a/include/tgbotxx/objects/Message.hpp
+++ b/include/tgbotxx/objects/Message.hpp
@@ -310,6 +310,9 @@ namespace tgbotxx {
       /// @brief Optional. Service message: a unique gift was sent or received
       Ptr<UniqueGiftInfo> uniqueGift{};
 
+      /// @brief Optional. Service message: upgrade of a gift was purchased after the gift was sent
+      Ptr<GiftInfo> giftUpgradeSent{};
+
       /// @brief Optional. The domain name of the website on which the user has logged in.
       /// @link More about Telegram Login » https://core.telegram.org/widgets/login @endlink
       std::string connectedWebsite;

--- a/include/tgbotxx/objects/MessageEntity.hpp
+++ b/include/tgbotxx/objects/MessageEntity.hpp
@@ -50,7 +50,9 @@ namespace tgbotxx {
       /// @brief “text_mention” (for users without usernames),
       TextMention,
       /// @brief “custom_emoji” (for inline custom emoji stickers)
-      CustomEmoji
+      CustomEmoji,
+      /// @brief “date_time” (for formatted date and time)
+      DateTime
     };
     /// @brief Converts enum Type to a string
     static std::optional<std::string> TypeToString(const Type type) noexcept {
@@ -73,6 +75,7 @@ namespace tgbotxx {
       if (type == Type::TextLink) return "text_link";
       if (type == Type::TextMention) return "text_mention";
       if (type == Type::CustomEmoji) return "custom_emoji";
+      if (type == Type::DateTime) return "date_time";
       return std::nullopt;
     }
     /// @brief Converts string to an enum Type
@@ -96,6 +99,7 @@ namespace tgbotxx {
       if (str == "text_link") return Type::TextLink;
       if (str == "text_mention") return Type::TextMention;
       if (str == "custom_emoji") return Type::CustomEmoji;
+      if (str == "date_time") return Type::DateTime;
       return std::nullopt;
     }
 
@@ -120,6 +124,7 @@ namespace tgbotxx {
     /// “text_link” (for clickable text URLs),
     /// “text_mention” (for users without usernames),
     /// “custom_emoji” (for inline custom emoji stickers)
+    /// “date_time” (for formatted date and time)
     Type type{};
 
     /// @brief Offset in UTF-16 code units to the start of the entity
@@ -141,6 +146,14 @@ namespace tgbotxx {
     /// Use Api::getCustomEmojiStickers to get full information about the sticker
     std::string customEmojiId;
 
+    /// @brief Optional. For “date_time” only, the Unix time associated with the entity
+    std::time_t unixTime{};
+
+    /// @brief Optional. For “date_time” only, the string that defines the formatting of the date and time.
+    /// See date-time entity formatting for more details.
+    /// @link "date-time entity formatting" https://core.telegram.org/bots/api#date-time-entity-formatting @endlink
+    std::string dateTimeFormat{};
+
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object
     nl::json toJson() const {
@@ -152,6 +165,8 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD_PTR(json, "user", user);
       OBJECT_SERIALIZE_FIELD(json, "language", language);
       OBJECT_SERIALIZE_FIELD(json, "custom_emoji_id", customEmojiId);
+      OBJECT_SERIALIZE_FIELD(json, "unix_time", unixTime);
+      OBJECT_SERIALIZE_FIELD(json, "date_time_format", dateTimeFormat);
       return json;
     }
 
@@ -164,6 +179,8 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD_PTR(json, "user", user, true);
       OBJECT_DESERIALIZE_FIELD(json, "language", language, "", true);
       OBJECT_DESERIALIZE_FIELD(json, "custom_emoji_id", customEmojiId, "", true);
+      OBJECT_DESERIALIZE_FIELD(json, "unix_time", unixTime, 0, true);
+      OBJECT_DESERIALIZE_FIELD(json, "date_time_format", dateTimeFormat, "", true);
     }
   };
 }

--- a/include/tgbotxx/objects/Object.hpp
+++ b/include/tgbotxx/objects/Object.hpp
@@ -15,156 +15,181 @@ namespace nl = nlohmann;
 
 /// @brief Helper macros to de/serialize objects
 
-#define TGBOTXX_CONCAT2(a, b) )
-#define VARNAME(x) CONCAT()
+
+/// Concatenate tokens
+#define TGBOTXX_CAT_IMPL(a, b) a##b
+#define TGBOTXX_CAT(a, b) TGBOTXX_CAT_IMPL(a, b)
+
+/// Avoid expanded variable names collisions
+#define VAR(x) TGBOTXX_CAT(x, __LINE__)
 
 /// Serialize
 #define OBJECT_SERIALIZE_FIELD(json, json_field, field) \
-  json[json_field] = field;
+  do {                                                  \
+    json[json_field] = field;                           \
+  } while (false)
 
 #define OBJECT_SERIALIZE_FIELD_PTR(json, json_field, field) \
-  if (field) {                                              \
-    json[json_field] = (field)->toJson();                   \
-  }
+  do {                                                      \
+    if (field) {                                            \
+      json[json_field] = (field)->toJson();                 \
+    }                                                       \
+  } while (false)
 
 #define OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, json_field, array_field) \
-  auto& arr = json[json_field] = nl::json::array();                     \
-  for (const auto& e: array_field)                                      \
-    arr.emplace_back(e->toJson());
+  do {                                                                  \
+    auto arr = json[json_field] = nl::json::array();                    \
+    for (const auto& e: array_field)                                    \
+      arr.emplace_back(e->toJson());                                    \
+  } while (false)
 
 #define OBJECT_SERIALIZE_FIELD_PTR_ARRAY_ARRAY(json, json_field, array_array_field) \
-  auto& root_arr = json[json_field] = nl::json::array();                            \
-  for (const auto& array: array_array_field) {                                      \
-    nl::json arr = nl::json::array();                                               \
-    for (const auto& e: array) {                                                    \
-      arr.emplace_back(e->toJson());                                                   \
+  do {                                                                              \
+    auto& root_arr = json[json_field] = nl::json::array();                          \
+    for (const auto& array: array_array_field) {                                    \
+      nl::json arr = nl::json::array();                                             \
+      for (const auto& e: array) {                                                  \
+        arr.emplace_back(e->toJson());                                              \
+      }                                                                             \
+      root_arr.emplace_back(arr);                                                   \
     }                                                                               \
-    root_arr.emplace_back(arr);                                                        \
-  }
+  } while (false)
 
 #define OBJECT_SERIALIZE_FIELD_ENUM(json, enum_name, json_field, field) \
-  json[json_field] = enum_name##ToString(field)
+  do {                                                                  \
+    json[json_field] = TGBOTXX_CAT(enum_name, ToString)(field);         \
+  } while (false)
 
 /// Deserialize
-#define OBJECT_DESERIALIZE_FIELD(json, json_field, field, default_value, optional)                \
-  if (json.contains(json_field)) {                                                                \
-    try {                                                                                         \
-      using T = std::remove_reference_t<std::remove_const_t<decltype(field)>>;                    \
-      field = json[json_field].get<T>();                                                          \
-    } catch (const std::exception& e) {                                                           \
-      std::ostringstream err{};                                                                   \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Failed to deserialize \""  \
-          << json_field << "\" from json object: " << json.dump(2) << "\nReason: " << e.what();   \
-      throw Exception(err.str());                                                                 \
-    } catch (...) {                                                                               \
-      std::ostringstream err{};                                                                   \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Failed to deserialize \""  \
-          << json_field << "\" from json object: " << json.dump(2);                               \
-      throw Exception(err.str());                                                                 \
-    }                                                                                             \
-  } else {                                                                                        \
-    if (not(optional)) {                                                                          \
-      std::ostringstream err{};                                                                   \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \"" \
-          << json_field << "\" from json object: " << json.dump(2);                               \
-      throw Exception(err.str());                                                                 \
-    }                                                                                             \
-    field = default_value;                                                                        \
-  }
+#define OBJECT_DESERIALIZE_FIELD(json, json_field, field, default_value, optional)                  \
+  do {                                                                                              \
+    if (json.contains(json_field)) {                                                                \
+      try {                                                                                         \
+        using T = std::remove_reference_t<std::remove_const_t<decltype(field)>>;                    \
+        field = json[json_field].get<T>();                                                          \
+      } catch (const std::exception& e) {                                                           \
+        std::ostringstream err{};                                                                   \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Failed to deserialize \""  \
+            << json_field << "\" from json object: " << json.dump(2) << "\nReason: " << e.what();   \
+        throw Exception(err.str());                                                                 \
+      } catch (...) {                                                                               \
+        std::ostringstream err{};                                                                   \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Failed to deserialize \""  \
+            << json_field << "\" from json object: " << json.dump(2);                               \
+        throw Exception(err.str());                                                                 \
+      }                                                                                             \
+    } else {                                                                                        \
+      if (not(optional)) {                                                                          \
+        std::ostringstream err{};                                                                   \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \"" \
+            << json_field << "\" from json object: " << json.dump(2);                               \
+        throw Exception(err.str());                                                                 \
+      }                                                                                             \
+      field = default_value;                                                                        \
+    }                                                                                               \
+  } while (false)
 
-#define OBJECT_DESERIALIZE_FIELD_PTR(json, json_field, field, optional)                                                \
-  static_assert(!std::is_const_v<decltype(field)>, "OBJECT_DESERIALIZE_FIELD_PTR: 'field' must not be const");         \
-  static_assert(std::is_same_v<decltype(optional), bool>, "OBJECT_DESERIALIZE_FIELD_PTR: 'optional' must be boolean"); \
-  if (json.contains(json_field) and json[json_field].is_object() and not json[json_field].empty()) {                   \
-    using T = std::remove_reference_t<decltype(field)>;                                                                \
-    using E = T::element_type;                                                                                         \
-    field = makePtr<E>(json[json_field]);                                                                              \
-  } else {                                                                                                             \
-    if (not(optional)) {                                                                                               \
-      std::ostringstream err{};                                                                                        \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \""                      \
-          << json_field << "\" from json object: " << json.dump(2);                                                    \
-      throw Exception(err.str());                                                                                      \
-    }                                                                                                                  \
-    field = nullptr;                                                                                                   \
-  }
+#define OBJECT_DESERIALIZE_FIELD_PTR(json, json_field, field, optional)                                                  \
+  do {                                                                                                                   \
+    static_assert(!std::is_const_v<decltype(field)>, "OBJECT_DESERIALIZE_FIELD_PTR: 'field' must not be const");         \
+    static_assert(std::is_same_v<decltype(optional), bool>, "OBJECT_DESERIALIZE_FIELD_PTR: 'optional' must be boolean"); \
+    if (json.contains(json_field) and json[json_field].is_object() and not json[json_field].empty()) {                   \
+      using T = std::remove_reference_t<decltype(field)>;                                                                \
+      using E = T::element_type;                                                                                         \
+      field = makePtr<E>(json[json_field]);                                                                              \
+    } else {                                                                                                             \
+      if (not(optional)) {                                                                                               \
+        std::ostringstream err{};                                                                                        \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \""                      \
+            << json_field << "\" from json object: " << json.dump(2);                                                    \
+        throw Exception(err.str());                                                                                      \
+      }                                                                                                                  \
+      field = nullptr;                                                                                                   \
+    }                                                                                                                    \
+  } while (false)
 
-#define OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, json_field, array_field, optional)                                          \
-  static_assert(!std::is_const_v<decltype(array_field)>, "OBJECT_DESERIALIZE_FIELD_PTR_ARRAY: 'field' must not be const");   \
-  static_assert(std::is_same_v<decltype(optional), bool>, "OBJECT_DESERIALIZE_FIELD_PTR_ARRAY: 'optional' must be boolean"); \
-  if ((json.contains(json_field)) and (json[json_field].is_array())) {                                                       \
-    using T = std::remove_reference_t<std::remove_const_t<decltype(array_field)::value_type>>;                               \
-    using E = T::element_type;                                                                                               \
-    array_field.clear();                                                                                                     \
-    array_field.reserve(json[json_field].size());                                                                            \
-    for (const nl::json& obj: json[json_field]) {                                                                            \
-      array_field.emplace_back(new E(obj));                                                                                  \
-    }                                                                                                                        \
-  } else {                                                                                                                   \
-    if (not(optional)) {                                                                                                     \
-      std::ostringstream err{};                                                                                              \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \""                            \
-          << json_field << "\" from json object: " << json.dump(2);                                                          \
-      throw Exception(err.str());                                                                                            \
-    }                                                                                                                        \
-    array_field.clear();                                                                                                     \
-  }
+#define OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, json_field, array_field, optional)                                            \
+  do {                                                                                                                         \
+    static_assert(!std::is_const_v<decltype(array_field)>, "OBJECT_DESERIALIZE_FIELD_PTR_ARRAY: 'field' must not be const");   \
+    static_assert(std::is_same_v<decltype(optional), bool>, "OBJECT_DESERIALIZE_FIELD_PTR_ARRAY: 'optional' must be boolean"); \
+    if ((json.contains(json_field)) and (json[json_field].is_array())) {                                                       \
+      using T = std::remove_reference_t<std::remove_const_t<decltype(array_field)::value_type>>;                               \
+      using E = T::element_type;                                                                                               \
+      array_field.clear();                                                                                                     \
+      array_field.reserve(json[json_field].size());                                                                            \
+      for (const nl::json& obj: json[json_field]) {                                                                            \
+        array_field.emplace_back(new E(obj));                                                                                  \
+      }                                                                                                                        \
+    } else {                                                                                                                   \
+      if (not(optional)) {                                                                                                     \
+        std::ostringstream err{};                                                                                              \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \""                            \
+            << json_field << "\" from json object: " << json.dump(2);                                                          \
+        throw Exception(err.str());                                                                                            \
+      }                                                                                                                        \
+      array_field.clear();                                                                                                     \
+    }                                                                                                                          \
+  } while (false)
 
 
-#define OBJECT_DESERIALIZE_FIELD_PTR_ARRAY_ARRAY(json, json_field, array_array_field, optional)                                        \
-  static_assert(!std::is_const_v<decltype(array_array_field)>, "OBJECT_DESERIALIZE_FIELD_PTR_ARRAY_ARRAY: 'field' must not be const"); \
-  static_assert(std::is_same_v<decltype(optional), bool>, "OBJECT_DESERIALIZE_FIELD_PTR_ARRAY_ARRAY: 'optional' must be boolean");     \
-  if ((json.contains(json_field)) and (json[json_field].is_array())) {                                                                 \
-    using ArrayArray = decltype(array_array_field);                                                                                    \
-    using Array = ArrayArray::value_type;         /* e.g vector<vector<int> <- > */                                                    \
-    using T = ArrayArray::value_type::value_type; /* e.g vector<vector<int>> <-  */                                                    \
-    using E = T::element_type;                                                                                                         \
-    array_array_field.clear();                                                                                                         \
-    array_array_field.reserve(json[json_field].size());                                                                                \
-    for (const nl::json& array: json[json_field]) {                                                                                    \
-      Array arr;                                                                                                                       \
-      arr.reserve(array.size());                                                                                                       \
-      for (const nl::json& obj: array) {                                                                                               \
-        arr.emplace_back(new E(obj));                                                                                                  \
-      }                                                                                                                                \
-      array_array_field.emplace_back(std::move(arr));                                                                                  \
-    }                                                                                                                                  \
-  } else {                                                                                                                             \
-    if (not(optional)) {                                                                                                               \
-      std::ostringstream err{};                                                                                                        \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \""                                      \
-          << json_field << "\" from json object: " << json.dump(2);                                                                    \
-      throw Exception(err.str());                                                                                                      \
-    }                                                                                                                                  \
-    array_array_field.clear();                                                                                                         \
-  }
+#define OBJECT_DESERIALIZE_FIELD_PTR_ARRAY_ARRAY(json, json_field, array_array_field, optional)                                          \
+  do {                                                                                                                                   \
+    static_assert(!std::is_const_v<decltype(array_array_field)>, "OBJECT_DESERIALIZE_FIELD_PTR_ARRAY_ARRAY: 'field' must not be const"); \
+    static_assert(std::is_same_v<decltype(optional), bool>, "OBJECT_DESERIALIZE_FIELD_PTR_ARRAY_ARRAY: 'optional' must be boolean");     \
+    if ((json.contains(json_field)) and (json[json_field].is_array())) {                                                                 \
+      using ArrayArray = decltype(array_array_field);                                                                                    \
+      using Array = ArrayArray::value_type;         /* e.g vector<vector<int> <- > */                                                    \
+      using T = ArrayArray::value_type::value_type; /* e.g vector<vector<int>> <-  */                                                    \
+      using E = T::element_type;                                                                                                         \
+      array_array_field.clear();                                                                                                         \
+      array_array_field.reserve(json[json_field].size());                                                                                \
+      for (const nl::json& array: json[json_field]) {                                                                                    \
+        Array arr;                                                                                                                       \
+        arr.reserve(array.size());                                                                                                       \
+        for (const nl::json& obj: array) {                                                                                               \
+          arr.emplace_back(new E(obj));                                                                                                  \
+        }                                                                                                                                \
+        array_array_field.emplace_back(std::move(arr));                                                                                  \
+      }                                                                                                                                  \
+    } else {                                                                                                                             \
+      if (not(optional)) {                                                                                                               \
+        std::ostringstream err{};                                                                                                        \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \""                                      \
+            << json_field << "\" from json object: " << json.dump(2);                                                                    \
+        throw Exception(err.str());                                                                                                      \
+      }                                                                                                                                  \
+      array_array_field.clear();                                                                                                         \
+    }                                                                                                                                    \
+  } while (false)
 
-#define OBJECT_DESERIALIZE_FIELD_ENUM(json, enum_name, json_field, field, default_value, optional)              \
-  static_assert(std::is_enum_v<decltype(field)>, "OBJECT_DESERIALIZE_FIELD_ENUM: 'field' must be an enum");     \
-  static_assert(!std::is_const_v<decltype(field)>, "OBJECT_DESERIALIZE_FIELD_ENUM: 'field' must not be const"); \
-  if (json.contains(json_field)) {                                                                              \
-    try {                                                                                                       \
-      if (auto opt = StringTo##enum_name(json[json_field]))                                                     \
-        field = *opt;                                                                                           \
-      else                                                                                                      \
-        throw Exception("Could not convert string \"" + json[json_field].get<std::string>() + "\" to enum");    \
-    } catch (const std::exception& e) {                                                                         \
-      std::ostringstream err{};                                                                                 \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Failed to deserialize \""                \
-          << json_field << "\" from json object: " << json.dump(2) << "\nReason: " << e.what();                 \
-      throw Exception(err.str());                                                                               \
-    } catch (...) {                                                                                             \
-      std::ostringstream err{};                                                                                 \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Failed to deserialize \""                \
-          << json_field << "\" from json object: " << json.dump(2);                                             \
-      throw Exception(err.str());                                                                               \
-    }                                                                                                           \
-  } else {                                                                                                      \
-    if (not(optional)) {                                                                                        \
-      std::ostringstream err{};                                                                                 \
-      err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \""               \
-          << json_field << "\" from json object: " << json.dump(2);                                             \
-      throw Exception(err.str());                                                                               \
-    }                                                                                                           \
-    field = static_cast<enum_name>(default_value);                                                              \
-  }
+#define OBJECT_DESERIALIZE_FIELD_ENUM(json, enum_name, json_field, field, default_value, optional)                \
+  do {                                                                                                            \
+    static_assert(std::is_enum_v<decltype(field)>, "OBJECT_DESERIALIZE_FIELD_ENUM: 'field' must be an enum");     \
+    static_assert(!std::is_const_v<decltype(field)>, "OBJECT_DESERIALIZE_FIELD_ENUM: 'field' must not be const"); \
+    if (json.contains(json_field)) {                                                                              \
+      try {                                                                                                       \
+        if (auto opt = TGBOTXX_CAT(StringTo, enum_name)(json[json_field]))                                        \
+          field = *opt;                                                                                           \
+        else                                                                                                      \
+          throw Exception("Could not convert string \"" + json[json_field].get<std::string>() + "\" to enum");    \
+      } catch (const std::exception& e) {                                                                         \
+        std::ostringstream err{};                                                                                 \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Failed to deserialize \""                \
+            << json_field << "\" from json object: " << json.dump(2) << "\nReason: " << e.what();                 \
+        throw Exception(err.str());                                                                               \
+      } catch (...) {                                                                                             \
+        std::ostringstream err{};                                                                                 \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Failed to deserialize \""                \
+            << json_field << "\" from json object: " << json.dump(2);                                             \
+        throw Exception(err.str());                                                                               \
+      }                                                                                                           \
+    } else {                                                                                                      \
+      if (not(optional)) {                                                                                        \
+        std::ostringstream err{};                                                                                 \
+        err << __FILE__ << ':' << __LINE__ << ": " << __FUNCTION__ << ": Missing required field \""               \
+            << json_field << "\" from json object: " << json.dump(2);                                             \
+        throw Exception(err.str());                                                                               \
+      }                                                                                                           \
+      field = static_cast<enum_name>(default_value);                                                              \
+    }                                                                                                             \
+  } while (false)

--- a/include/tgbotxx/objects/Object.hpp
+++ b/include/tgbotxx/objects/Object.hpp
@@ -15,28 +15,31 @@ namespace nl = nlohmann;
 
 /// @brief Helper macros to de/serialize objects
 
+#define TGBOTXX_CONCAT2(a, b) )
+#define VARNAME(x) CONCAT()
+
 /// Serialize
 #define OBJECT_SERIALIZE_FIELD(json, json_field, field) \
   json[json_field] = field;
 
 #define OBJECT_SERIALIZE_FIELD_PTR(json, json_field, field) \
   if (field) {                                              \
-    json[json_field] = (field)->toJson();                     \
+    json[json_field] = (field)->toJson();                   \
   }
 
 #define OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, json_field, array_field) \
-  json[json_field] = nl::json::array();                                 \
+  auto& arr = json[json_field] = nl::json::array();                     \
   for (const auto& e: array_field)                                      \
-    json[json_field].push_back(e->toJson());
+    arr.emplace_back(e->toJson());
 
 #define OBJECT_SERIALIZE_FIELD_PTR_ARRAY_ARRAY(json, json_field, array_array_field) \
-  json[json_field] = nl::json::array();                                             \
+  auto& root_arr = json[json_field] = nl::json::array();                            \
   for (const auto& array: array_array_field) {                                      \
     nl::json arr = nl::json::array();                                               \
     for (const auto& e: array) {                                                    \
-      arr.push_back(e->toJson());                                                   \
+      arr.emplace_back(e->toJson());                                                   \
     }                                                                               \
-    json[json_field].push_back(arr);                                                \
+    root_arr.emplace_back(arr);                                                        \
   }
 
 #define OBJECT_SERIALIZE_FIELD_ENUM(json, enum_name, json_field, field) \
@@ -75,7 +78,7 @@ namespace nl = nlohmann;
   if (json.contains(json_field) and json[json_field].is_object() and not json[json_field].empty()) {                   \
     using T = std::remove_reference_t<decltype(field)>;                                                                \
     using E = T::element_type;                                                                                         \
-    field.reset(new (E)(json[json_field]));                                                                            \
+    field = makePtr<E>(json[json_field]);                                                                              \
   } else {                                                                                                             \
     if (not(optional)) {                                                                                               \
       std::ostringstream err{};                                                                                        \
@@ -92,6 +95,7 @@ namespace nl = nlohmann;
   if ((json.contains(json_field)) and (json[json_field].is_array())) {                                                       \
     using T = std::remove_reference_t<std::remove_const_t<decltype(array_field)::value_type>>;                               \
     using E = T::element_type;                                                                                               \
+    array_field.clear();                                                                                                     \
     array_field.reserve(json[json_field].size());                                                                            \
     for (const nl::json& obj: json[json_field]) {                                                                            \
       array_field.emplace_back(new E(obj));                                                                                  \
@@ -115,6 +119,7 @@ namespace nl = nlohmann;
     using Array = ArrayArray::value_type;         /* e.g vector<vector<int> <- > */                                                    \
     using T = ArrayArray::value_type::value_type; /* e.g vector<vector<int>> <-  */                                                    \
     using E = T::element_type;                                                                                                         \
+    array_array_field.clear();                                                                                                         \
     array_array_field.reserve(json[json_field].size());                                                                                \
     for (const nl::json& array: json[json_field]) {                                                                                    \
       Array arr;                                                                                                                       \
@@ -122,7 +127,7 @@ namespace nl = nlohmann;
       for (const nl::json& obj: array) {                                                                                               \
         arr.emplace_back(new E(obj));                                                                                                  \
       }                                                                                                                                \
-      array_array_field.push_back(std::move(arr));                                                                                     \
+      array_array_field.emplace_back(std::move(arr));                                                                                  \
     }                                                                                                                                  \
   } else {                                                                                                                             \
     if (not(optional)) {                                                                                                               \
@@ -140,7 +145,7 @@ namespace nl = nlohmann;
   if (json.contains(json_field)) {                                                                              \
     try {                                                                                                       \
       if (auto opt = StringTo##enum_name(json[json_field]))                                                     \
-        field = *opt;                                                                                            \
+        field = *opt;                                                                                           \
       else                                                                                                      \
         throw Exception("Could not convert string \"" + json[json_field].get<std::string>() + "\" to enum");    \
     } catch (const std::exception& e) {                                                                         \

--- a/include/tgbotxx/objects/UniqueGift.hpp
+++ b/include/tgbotxx/objects/UniqueGift.hpp
@@ -3,6 +3,7 @@
 #include <tgbotxx/objects/UniqueGiftModel.hpp>
 #include <tgbotxx/objects/UniqueGiftSymbol.hpp>
 #include <tgbotxx/objects/UniqueGiftBackdrop.hpp>
+#include <tgbotxx/objects/UniqueGiftColors.hpp>
 #include <tgbotxx/objects/Chat.hpp>
 
 namespace tgbotxx {
@@ -13,6 +14,9 @@ namespace tgbotxx {
     explicit UniqueGift(const nl::json& json) {
       fromJson(json);
     }
+
+    /// @brief Identifier of the regular gift from which the gift was upgraded
+    std::string giftId;
 
     /// @brief Human-readable name of the regular gift from which this unique gift was upgraded
     std::string baseName;
@@ -32,31 +36,54 @@ namespace tgbotxx {
     /// @brief Backdrop of the gift
     Ptr<UniqueGiftBackdrop> backdrop;
 
+    /// @brief Optional. True, if the original regular gift was exclusively purchaseable by Telegram Premium subscribers
+    bool isPremium{};
+
+    /// @brief Optional. True, if the gift was used to craft another gift and isn't available anymore
+    bool isBurned{};
+
+    /// @brief Optional. True, if the gift is assigned from the TON blockchain and can't be resold or transferred in Telegram
+    bool isFromBlockchain{};
+
+    /// @brief Optional. The color scheme that can be used by the gift's owner for the chat's name, replies to messages and link previews;
+    /// for business account gifts and gifts that are currently on sale only
+    Ptr<UniqueGiftColors> colors;
+
     /// @brief Optional. Information about the chat that published the gift
     Ptr<Chat> publisherChat;
 
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object
-    nl::json toJson() const {
+    [[nodiscard]] nl::json toJson() const {
       nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD(json, "gift_id", giftId);
       OBJECT_SERIALIZE_FIELD(json, "base_name", baseName);
       OBJECT_SERIALIZE_FIELD(json, "name", name);
       OBJECT_SERIALIZE_FIELD(json, "number", number);
       OBJECT_SERIALIZE_FIELD_PTR(json, "model", model);
       OBJECT_SERIALIZE_FIELD_PTR(json, "symbol", symbol);
       OBJECT_SERIALIZE_FIELD_PTR(json, "backdrop", backdrop);
+      OBJECT_SERIALIZE_FIELD(json, "is_premium", isPremium);
+      OBJECT_SERIALIZE_FIELD(json, "is_burned", isBurned);
+      OBJECT_SERIALIZE_FIELD(json, "is_from_blockchain", isFromBlockchain);
+      OBJECT_SERIALIZE_FIELD_PTR(json, "colors", colors);
       OBJECT_SERIALIZE_FIELD_PTR(json, "publisher_chat", publisherChat);
       return json;
     }
 
     /// @brief Deserializes this object from JSON
     void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD(json, "gift_id", giftId, "", false);
       OBJECT_DESERIALIZE_FIELD(json, "base_name", baseName, "", false);
       OBJECT_DESERIALIZE_FIELD(json, "name", name, "", false);
       OBJECT_DESERIALIZE_FIELD(json, "number", number, 0, false);
       OBJECT_DESERIALIZE_FIELD_PTR(json, "model", model, false);
       OBJECT_DESERIALIZE_FIELD_PTR(json, "symbol", symbol, false);
       OBJECT_DESERIALIZE_FIELD_PTR(json, "backdrop", backdrop, false);
+      OBJECT_DESERIALIZE_FIELD(json, "is_premium", isPremium, false, true);
+      OBJECT_DESERIALIZE_FIELD(json, "is_burned", isBurned, false, true);
+      OBJECT_DESERIALIZE_FIELD(json, "is_from_blockchain", isFromBlockchain, false, true);
+      OBJECT_DESERIALIZE_FIELD_PTR(json, "colors", colors, true);
       OBJECT_DESERIALIZE_FIELD_PTR(json, "publisher_chat", publisherChat, true);
     }
   };

--- a/include/tgbotxx/objects/UniqueGiftColors.hpp
+++ b/include/tgbotxx/objects/UniqueGiftColors.hpp
@@ -1,0 +1,54 @@
+#pragma once
+#include <tgbotxx/objects/Object.hpp>
+
+namespace tgbotxx {
+  /// @brief This object contains information about the color scheme for a user's name, message replies and link previews based on a unique gift.
+  /// @ref https://core.telegram.org/bots/api#uniquegiftcolors
+  struct UniqueGiftColors {
+    UniqueGiftColors() = default;
+    explicit UniqueGiftColors(const nl::json& json) {
+      fromJson(json);
+    }
+
+    /// @brief Custom emoji identifier of the unique gift's model
+    std::string modelCustomEmojiId{};
+
+    /// @brief Custom emoji identifier of the unique gift's symbol
+    std::string symbolCustomEmojiId{};
+
+    /// @brief Main color used in light themes; RGB format
+    std::int32_t lightThemeMainColor{};
+
+    /// @brief List of 1-3 additional colors used in light themes; RGB format
+    std::vector<std::int32_t> lightThemeOtherColors;
+
+    /// @brief Main color used in dark themes; RGB format
+    std::int32_t darkThemeMainColor{};
+
+    /// @brief List of 1-3 additional colors used in dark themes; RGB format
+    std::vector<std::int32_t> darkThemeOtherColors;
+
+    /// @brief Serializes this object to JSON
+    nl::json toJson() const {
+      nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD(json, "model_custom_emoji_id", modelCustomEmojiId);
+      OBJECT_SERIALIZE_FIELD(json, "symbol_custom_emoji_id", symbolCustomEmojiId);
+      OBJECT_SERIALIZE_FIELD(json, "light_theme_main_color", lightThemeMainColor);
+      OBJECT_SERIALIZE_FIELD(json, "light_theme_other_colors", lightThemeOtherColors);
+      OBJECT_SERIALIZE_FIELD(json, "dark_theme_main_color", darkThemeMainColor);
+      OBJECT_SERIALIZE_FIELD(json, "dark_theme_other_colors", darkThemeOtherColors);
+      return json;
+    }
+
+    /// @brief Deserializes this object from JSON
+    void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD(json, "model_custom_emoji_id", modelCustomEmojiId, "", false);
+      OBJECT_DESERIALIZE_FIELD(json, "symbol_custom_emoji_id", symbolCustomEmojiId, "", false);
+      OBJECT_DESERIALIZE_FIELD(json, "light_theme_main_color", lightThemeMainColor, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "light_theme_other_colors", lightThemeOtherColors, {}, false);
+      OBJECT_DESERIALIZE_FIELD(json, "dark_theme_main_color", darkThemeMainColor, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "dark_theme_other_colors", darkThemeOtherColors, {}, false);
+    }
+  };
+
+}

--- a/include/tgbotxx/objects/UniqueGiftInfo.hpp
+++ b/include/tgbotxx/objects/UniqueGiftInfo.hpp
@@ -14,15 +14,20 @@ namespace tgbotxx {
     /// @brief Information about the gift
     Ptr<UniqueGift> gift;
 
-    /// @brief Origin of the gift.
-    /// Currently, either
-    /// “upgrade” for gifts upgraded from regular gifts,
-    /// “transfer” for gifts transferred from other users or channels, or
-    /// “resale” for gifts bought from other users
+    /// @briefOrigin of the gift. Currently, either:
+    /// - “upgrade” for gifts upgraded from regular gifts,
+    /// - “transfer” for gifts transferred from other users or channels,
+    /// - “resale” for gifts bought from other users,
+    /// - “gifted_upgrade” for upgrades purchased after the gift was sent, or
+    /// - “offer” for gifts bought or sold through gift purchase offers
     std::string origin;
 
-    /// @brief Optional. For gifts bought from other users, the price paid for the gift
-    std::int64_t lastResaleStarCount{};
+    /// @brief Optional. For gifts bought from other users, the currency in which the payment for the gift was done.
+    /// Currently, one of “XTR” for Telegram Stars or “TON” for toncoins.
+    std::string lastResaleCurrency{};
+
+    /// @brief Optional. For gifts bought from other users, the price paid for the gift in either Telegram Stars or nanotoncoins
+    std::int64_t lastResaleAmount{};
 
     /// @brief Optional. Unique identifier of the received gift for the bot;
     /// only present for gifts received on behalf of business accounts
@@ -42,7 +47,8 @@ namespace tgbotxx {
       nl::json json = nl::json::object();
       OBJECT_SERIALIZE_FIELD_PTR(json, "gift", gift);
       OBJECT_SERIALIZE_FIELD(json, "origin", origin);
-      OBJECT_SERIALIZE_FIELD(json, "last_resale_star_count", lastResaleStarCount);
+      OBJECT_SERIALIZE_FIELD(json, "last_resale_currency", lastResaleCurrency);
+      OBJECT_SERIALIZE_FIELD(json, "last_resale_amount", lastResaleAmount);
       OBJECT_SERIALIZE_FIELD(json, "owned_gift_id", ownedGiftId);
       OBJECT_SERIALIZE_FIELD(json, "transfer_star_count", transferStarCount);
       OBJECT_SERIALIZE_FIELD(json, "next_transfer_date", nextTransferDate);
@@ -53,7 +59,8 @@ namespace tgbotxx {
     void fromJson(const nl::json& json) {
       OBJECT_DESERIALIZE_FIELD_PTR(json, "gift", gift, false);
       OBJECT_DESERIALIZE_FIELD(json, "origin", origin, "", false);
-      OBJECT_DESERIALIZE_FIELD(json, "last_resale_star_count", lastResaleStarCount, 0, true);
+      OBJECT_DESERIALIZE_FIELD(json, "last_resale_currency", lastResaleCurrency, "", true);
+      OBJECT_DESERIALIZE_FIELD(json, "last_resale_amount", lastResaleAmount, 0, true);
       OBJECT_DESERIALIZE_FIELD(json, "owned_gift_id", ownedGiftId, "", true);
       OBJECT_DESERIALIZE_FIELD(json, "transfer_star_count", transferStarCount, 0, true);
       OBJECT_DESERIALIZE_FIELD(json, "next_transfer_date", nextTransferDate, 0, true);

--- a/include/tgbotxx/objects/UniqueGiftModel.hpp
+++ b/include/tgbotxx/objects/UniqueGiftModel.hpp
@@ -17,8 +17,11 @@ namespace tgbotxx {
     /// @brief The sticker that represents the unique gift
     Ptr<Sticker> sticker;
 
-    /// @brief The number of unique gifts that receive this model for every 1000 gifts upgraded
+    /// @brief The number of unique gifts that receive this model for every 1000 gift upgrades. Always 0 for crafted gifts.
     std::int32_t rarityPerMille{};
+
+    /// @brief Optional. Rarity of the model if it is a crafted model. Currently, can be “uncommon”, “rare”, “epic”, or “legendary”.
+    std::string rarity;
 
     /// @brief Serializes this object to JSON
     nl::json toJson() const {
@@ -26,6 +29,7 @@ namespace tgbotxx {
       OBJECT_SERIALIZE_FIELD(json, "name", name);
       OBJECT_SERIALIZE_FIELD_PTR(json, "sticker", sticker);
       OBJECT_SERIALIZE_FIELD(json, "rarity_per_mille", rarityPerMille);
+      OBJECT_SERIALIZE_FIELD(json, "rarity", rarity);
       return json;
     }
 
@@ -34,6 +38,7 @@ namespace tgbotxx {
       OBJECT_DESERIALIZE_FIELD(json, "name", name, "", false);
       OBJECT_DESERIALIZE_FIELD_PTR(json, "sticker", sticker, false);
       OBJECT_DESERIALIZE_FIELD(json, "rarity_per_mille", rarityPerMille, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "rarity", rarity, "", true);
     }
   };
 }

--- a/include/tgbotxx/objects/User.hpp
+++ b/include/tgbotxx/objects/User.hpp
@@ -54,6 +54,9 @@ namespace tgbotxx {
     /// @brief Optional. True, if the bot has forum topic mode enabled in private chats. Returned only in getMe.
     bool hasTopicsEnabled{};
 
+    /// @brief Optional. True, if the bot allows users to create and delete topics in private chats. Returned only in getMe.
+    bool allowsUsersToCreateTopics{};
+
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object
     [[nodiscard]] nl::json toJson() const;

--- a/include/tgbotxx/objects/User.hpp
+++ b/include/tgbotxx/objects/User.hpp
@@ -51,6 +51,9 @@ namespace tgbotxx {
     /// @brief Optional. True, if the bot has a main Web App. Returned only in getMe.
     bool hasMainWebApp{};
 
+    /// @brief Optional. True, if the bot has forum topic mode enabled in private chats. Returned only in getMe.
+    bool hasTopicsEnabled{};
+
     /// @brief Serializes this object to JSON
     /// @returns JSON representation of this object
     [[nodiscard]] nl::json toJson() const;

--- a/include/tgbotxx/objects/UserProfileAudios.hpp
+++ b/include/tgbotxx/objects/UserProfileAudios.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <tgbotxx/objects/Object.hpp>
+#include <tgbotxx/objects/Audio.hpp>
+
+namespace tgbotxx {
+  /// @brief This object represents the audios displayed on a user's profile.
+  /// @ref https://core.telegram.org/bots/api#userprofileaudios
+  struct UserProfileAudios {
+    UserProfileAudios() = default;
+    explicit UserProfileAudios(const nl::json& json) {
+      fromJson(json);
+    }
+
+    /// @brief Total number of profile audios for the target user
+    std::int32_t totalCount;
+
+    /// @brief Requested profile audios
+    std::vector<Ptr<Audio>> audios;
+
+
+    /// @brief Serializes this object to JSON
+    /// @returns JSON representation of this object
+    nl::json toJson() const {
+      nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD(json, "total_count", totalCount);
+      OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, "audios", audios);
+      return json;
+    }
+
+    /// @brief Deserializes this object from JSON
+    void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD(json, "total_count", totalCount, 0, false);
+      OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, "audios", audios, false);
+    }
+  };
+}

--- a/include/tgbotxx/objects/UserRating.hpp
+++ b/include/tgbotxx/objects/UserRating.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include <tgbotxx/objects/Object.hpp>
+
+namespace tgbotxx {
+  /// @brief This object describes the rating of a user based on their Telegram Star spendings.
+  /// @ref https://core.telegram.org/bots/api#userrating
+  struct UserRating {
+    UserRating() = default;
+    explicit UserRating(const nl::json& json);
+
+    /// @brief Current level of the user, indicating their reliability when purchasing digital goods and services.
+    /// A higher level suggests a more trustworthy customer; a negative level is likely reason for concern.
+    std::int32_t level{};
+
+    /// @brief Numerical value of the user's rating; the higher the rating, the better
+    std::int32_t rating{};
+
+    /// @brief The rating value required to get the current level
+    std::int32_t currentLevelRating{};
+
+    /// @brief Optional. The rating value required to get to the next level; omitted if the maximum level was reached
+    std::int32_t nextLevelRating{};
+
+
+    /// @brief Serializes this object to JSON
+    /// @returns JSON representation of this object
+    nl::json toJson() const {
+      nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD(json, "level", level);
+      OBJECT_SERIALIZE_FIELD(json, "rating", rating);
+      OBJECT_SERIALIZE_FIELD(json, "current_level_rating", currentLevelRating);
+      OBJECT_SERIALIZE_FIELD(json, "next_level_rating", nextLevelRating);
+      return json;
+    }
+
+    /// @brief Deserializes this object from JSON
+    void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD(json, "level", level, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "rating", rating, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "current_level_rating", currentLevelRating, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "next_level_rating", nextLevelRating, 0, true);
+    }
+  };
+}

--- a/include/tgbotxx/objects/Video.hpp
+++ b/include/tgbotxx/objects/Video.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <tgbotxx/objects/Object.hpp>
 #include <tgbotxx/objects/PhotoSize.hpp>
+#include <tgbotxx/objects/VideoQuality.hpp>
 
 namespace tgbotxx {
   /// @brief This object represents a video file.
@@ -36,6 +37,9 @@ namespace tgbotxx {
       /// @brief Optional. Timestamp in seconds from which the video will play in the message
       std::time_t startTimestamp{};
 
+      /// @brief Optional. List of available qualities of the video
+      std::vector<Ptr<VideoQuality>> qualities;
+
       /// @brief Optional. Original filename as defined by sender
       std::string fileName;
 
@@ -59,6 +63,7 @@ namespace tgbotxx {
         OBJECT_SERIALIZE_FIELD_PTR(json, "thumbnail", thumbnail);
         OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, "cover", cover);
         OBJECT_SERIALIZE_FIELD(json, "start_timestamp", startTimestamp);
+        OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, "qualities", qualities);
         OBJECT_SERIALIZE_FIELD(json, "file_name", fileName);
         OBJECT_SERIALIZE_FIELD(json, "mime_type", mimeType);
         OBJECT_SERIALIZE_FIELD(json, "file_size", fileSize);
@@ -75,6 +80,7 @@ namespace tgbotxx {
         OBJECT_DESERIALIZE_FIELD_PTR(json, "thumbnail", thumbnail, true);
         OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, "cover", cover, true);
         OBJECT_DESERIALIZE_FIELD(json, "start_timestamp", startTimestamp, 0, true);
+        OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, "qualities", qualities, true);
         OBJECT_DESERIALIZE_FIELD(json, "file_name", fileName, "", true);
         OBJECT_DESERIALIZE_FIELD(json, "mime_type", mimeType, "", true);
         OBJECT_DESERIALIZE_FIELD(json, "file_size", fileSize, 0, true);

--- a/include/tgbotxx/objects/VideoQuality.hpp
+++ b/include/tgbotxx/objects/VideoQuality.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#include <tgbotxx/objects/Object.hpp>
+
+namespace tgbotxx {
+  /// @brief This object represents a video file of a specific quality.
+  /// @ref https://core.telegram.org/bots/api#videoquality
+  struct VideoQuality {
+    VideoQuality() = default;
+    explicit VideoQuality(const nl::json& json) {
+      fromJson(json);
+    }
+
+    /// @brief Identifier for this file, which can be used to download or reuse the file
+    std::string fileId;
+
+    /// @brief Unique identifier for this file, which is supposed to be the same over time and for different bots.
+    /// Can't be used to download or reuse the file.
+    std::string fileUniqueId;
+
+    /// @brief Video width
+    std::int32_t width{};
+
+    /// @brief Video height
+    std::int32_t height{};
+
+    /// @brief Codec that was used to encode the video, for example, “h264”, “h265”, or “av01”
+    std::string codec;
+
+    /// @brief Optional. File size in bytes.
+    /// It can be bigger than 2^31 and some programming languages may have difficulty/silent defects in interpreting it.
+    /// But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this value.
+    std::int64_t fileSize{};
+
+
+    /// @brief Serializes this object to JSON
+    /// @returns JSON representation of this object
+    nl::json toJson() const {
+      nl::json json = nl::json::object();
+      OBJECT_SERIALIZE_FIELD(json, "file_id", fileId);
+      OBJECT_SERIALIZE_FIELD(json, "file_unique_id", fileUniqueId);
+      OBJECT_SERIALIZE_FIELD(json, "width", width);
+      OBJECT_SERIALIZE_FIELD(json, "height", height);
+      OBJECT_SERIALIZE_FIELD(json, "codec", codec);
+      OBJECT_SERIALIZE_FIELD(json, "file_size", fileSize);
+      return json;
+    }
+
+    /// @brief Deserializes this object from JSON
+    void fromJson(const nl::json& json) {
+      OBJECT_DESERIALIZE_FIELD(json, "file_id", fileId, "", false);
+      OBJECT_DESERIALIZE_FIELD(json, "file_unique_id", fileUniqueId, "", false);
+      OBJECT_DESERIALIZE_FIELD(json, "width", width, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "height", height, 0, false);
+      OBJECT_DESERIALIZE_FIELD(json, "codec", codec, "", false);
+      OBJECT_DESERIALIZE_FIELD(json, "file_size", fileSize, 0, true);
+    }
+  };
+}

--- a/include/tgbotxx/tgbotxx.hpp
+++ b/include/tgbotxx/tgbotxx.hpp
@@ -39,6 +39,8 @@
 #include <tgbotxx/objects/ChatLocation.hpp>
 #include <tgbotxx/objects/ChatMember.hpp>
 #include <tgbotxx/objects/ChatMemberUpdated.hpp>
+#include <tgbotxx/objects/ChatOwnerLeft.hpp>
+#include <tgbotxx/objects/ChatOwnerChanged.hpp>
 #include <tgbotxx/objects/ChatPermissions.hpp>
 #include <tgbotxx/objects/ChatPhoto.hpp>
 #include <tgbotxx/objects/ChatShared.hpp>
@@ -172,6 +174,7 @@
 #include <tgbotxx/objects/UserChatBoosts.hpp>
 #include <tgbotxx/objects/User.hpp>
 #include <tgbotxx/objects/UserProfilePhotos.hpp>
+#include <tgbotxx/objects/UserProfileAudios.hpp>
 #include <tgbotxx/objects/UserRating.hpp>
 #include <tgbotxx/objects/UsersShared.hpp>
 #include <tgbotxx/objects/Venue.hpp>
@@ -179,6 +182,7 @@
 #include <tgbotxx/objects/VideoChatParticipantsInvited.hpp>
 #include <tgbotxx/objects/VideoChatScheduled.hpp>
 #include <tgbotxx/objects/VideoChatStarted.hpp>
+#include <tgbotxx/objects/VideoQuality.hpp>
 #include <tgbotxx/objects/Video.hpp>
 #include <tgbotxx/objects/VideoNote.hpp>
 #include <tgbotxx/objects/Voice.hpp>

--- a/include/tgbotxx/tgbotxx.hpp
+++ b/include/tgbotxx/tgbotxx.hpp
@@ -172,6 +172,7 @@
 #include <tgbotxx/objects/UserChatBoosts.hpp>
 #include <tgbotxx/objects/User.hpp>
 #include <tgbotxx/objects/UserProfilePhotos.hpp>
+#include <tgbotxx/objects/UserRating.hpp>
 #include <tgbotxx/objects/UsersShared.hpp>
 #include <tgbotxx/objects/Venue.hpp>
 #include <tgbotxx/objects/VideoChatEnded.hpp>

--- a/include/tgbotxx/tgbotxx.hpp
+++ b/include/tgbotxx/tgbotxx.hpp
@@ -68,6 +68,7 @@
 #include <tgbotxx/objects/GeneralForumTopicHidden.hpp>
 #include <tgbotxx/objects/GeneralForumTopicUnhidden.hpp>
 #include <tgbotxx/objects/Gift.hpp>
+#include <tgbotxx/objects/GiftBackground.hpp>
 #include <tgbotxx/objects/GiftInfo.hpp>
 #include <tgbotxx/objects/Gifts.hpp>
 #include <tgbotxx/objects/GiveawayCompleted.hpp>
@@ -162,6 +163,7 @@
 #include <tgbotxx/objects/TransactionPartner.hpp>
 #include <tgbotxx/objects/UniqueGiftBackdropColors.hpp>
 #include <tgbotxx/objects/UniqueGiftBackdrop.hpp>
+#include <tgbotxx/objects/UniqueGiftColors.hpp>
 #include <tgbotxx/objects/UniqueGift.hpp>
 #include <tgbotxx/objects/UniqueGiftInfo.hpp>
 #include <tgbotxx/objects/UniqueGiftModel.hpp>

--- a/include/tgbotxx/utils/DateTimeUtils.hpp
+++ b/include/tgbotxx/utils/DateTimeUtils.hpp
@@ -10,28 +10,38 @@ namespace tgbotxx {
     /// @brief Converts an std::time_t to a string date time with a specific format
     /// @param time std::time_t value to convert
     /// @param format Format of the date to return. Default %Y-%m-%d %H:%M:%S (e.g 2023-10-25 12:55:05) https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html
-    /// @returns time as string date time with the specific format
+    /// @returns on success: time as string datetime with the specific format
+    ///          on failure: empty std::string
     [[nodiscard]] static std::string toString(const std::time_t& time, const std::string_view& format = "%Y-%m-%d %H:%M:%S") {
-      char buffer[128]{};
-      tm tm_{};
+      std::tm tm_{};
+
 #ifdef _WIN32
       localtime_s(&tm_, &time);
 #else
-      tm_ = *std::localtime(&time);
+      localtime_r(&time, &tm_);
 #endif
-      std::strftime(buffer, sizeof(buffer), format.data(), &tm_);
-      return std::string{buffer};
+
+      std::string result(128, '\0');
+      const std::size_t size = std::strftime(result.data(), result.size(), format.data(), &tm_);
+      if (size == 0) return {};
+
+      result.resize(size);
+      return result;
     }
 
     /// @brief Converts a string date time with a specific format to an std::time_t
     /// @param dateTimeStr String date time to convert
     /// @param format Format of the string date to return. Default %Y-%m-%d %H:%M:%S (e.g 2023-10-25 12:55:05) https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html
-    /// @returns std::time_t
+    /// @returns non-negative std::time_t on success
     [[nodiscard]] static std::time_t fromString(const std::string& dateTimeStr, const std::string_view& format = "%Y-%m-%d %H:%M:%S") {
       std::tm tm{};
       std::istringstream iss{dateTimeStr};
-      iss >> std::get_time(&tm, format.data());
-      tm.tm_isdst = -1; // let mktime() determine DST correctly
+
+      if (!(iss >> std::get_time(&tm, format.data()))) {
+        return -1; // failed to parse dateTimeStr
+      }
+
+      tm.tm_isdst = -1;
       return std::mktime(&tm);
     }
 
@@ -43,8 +53,7 @@ namespace tgbotxx {
       return toString(tm, format);
     }
 
-    [[deprecated("Use DateTimeUtils::now() instead")]]
-    [[nodiscard]] static std::string currentDateTime(const std::string_view& format = "%Y-%m-%d %H:%M:%S") {
+    [[deprecated("Use DateTimeUtils::now() instead")]] [[nodiscard]] static std::string currentDateTime(const std::string_view& format = "%Y-%m-%d %H:%M:%S") {
       return now(format);
     }
 

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -234,11 +234,12 @@ Ptr<Message> Api::forwardMessage(const std::variant<std::int64_t, std::string>& 
                                  std::int32_t messageThreadId,
                                  bool disableNotification,
                                  bool protectContent,
+                                 const std::string& messageEffectId,
                                  std::int32_t directMessagesTopicId,
                                  std::time_t videoStartTimestamp,
                                  const Ptr<SuggestedPostParameters>& suggestedPostParameters) const {
   cpr::Multipart data{};
-  data.parts.reserve(6);
+  data.parts.reserve(7);
   data.parts.emplace_back("chat_id", chatId.index() == 0 ? std::to_string(std::get<0>(chatId)) : std::get<1>(chatId));                  // Since cpr::Part() does not take 64bit integers (only 32bit), passing a 64bit chatId to 32bit integer gets overflown and sends wrong chat_id which causes Bad Request: chat not found
   data.parts.emplace_back("from_chat_id", fromChatId.index() == 0 ? std::to_string(std::get<0>(fromChatId)) : std::get<1>(fromChatId)); // Since cpr::Part() does not take 64bit integers (only 32bit), passing a 64bit chatId to 32bit integer gets overflown and sends wrong chat_id which causes Bad Request: chat not found
   data.parts.emplace_back("message_id", messageId);
@@ -248,6 +249,8 @@ Ptr<Message> Api::forwardMessage(const std::variant<std::int64_t, std::string>& 
     data.parts.emplace_back("disable_notification", disableNotification);
   if (protectContent)
     data.parts.emplace_back("protect_content", protectContent);
+  if (not messageEffectId.empty())
+    data.parts.emplace_back("message_effect_id", messageEffectId);
   if (directMessagesTopicId)
     data.parts.emplace_back("direct_messages_topic_id", directMessagesTopicId);
   if (videoStartTimestamp)
@@ -300,6 +303,7 @@ Ptr<MessageId> Api::copyMessage(const std::variant<std::int64_t, std::string>& c
                                 const std::vector<Ptr<MessageEntity>>& captionEntities,
                                 bool disableNotification,
                                 bool protectContent,
+                                const std::string& messageEffectId,
                                 const Ptr<IReplyMarkup>& replyMarkup,
                                 std::int32_t directMessagesTopicId,
                                 std::time_t videoStartTimestamp,
@@ -326,6 +330,8 @@ Ptr<MessageId> Api::copyMessage(const std::variant<std::int64_t, std::string>& c
   }
   if (disableNotification)
     data.parts.emplace_back("disable_notification", disableNotification);
+  if (not messageEffectId.empty())
+    data.parts.emplace_back("message_effect_id", messageEffectId);
   if (protectContent)
     data.parts.emplace_back("protect_content", protectContent);
   if (replyMarkup)
@@ -2650,6 +2656,26 @@ Ptr<Story> Api::postStory(const std::string& businessConnectionId,
     data.parts.emplace_back("protect_content", protectContent);
 
   return makePtr<Story>(sendRequest("postStory", data));
+}
+
+Ptr<Story> Api::repostStory(const std::string& businessConnectionId,
+                            std::int64_t fromChatId,
+                            std::int32_t fromStoryId,
+                            std::time_t activePeriod,
+                            bool postToChatPage,
+                            bool protectContent) const {
+  cpr::Multipart data{};
+  data.parts.reserve(6);
+  data.parts.emplace_back("business_connection_id", businessConnectionId);
+  data.parts.emplace_back("from_chat_id", std::to_string(fromChatId));
+  data.parts.emplace_back("from_story_id", std::to_string(fromStoryId));
+  data.parts.emplace_back("active_period", std::to_string(activePeriod));
+  if (postToChatPage)
+    data.parts.emplace_back("post_to_chat_page", postToChatPage);
+  if (protectContent)
+    data.parts.emplace_back("protect_content", protectContent);
+
+  return makePtr<Story>(sendRequest("repostStory", data));
 }
 
 Ptr<Story> Api::editStory(const std::string& businessConnectionId,

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -44,6 +44,7 @@
 #include <tgbotxx/objects/Update.hpp>
 #include <tgbotxx/objects/User.hpp>
 #include <tgbotxx/objects/UserProfilePhotos.hpp>
+#include <tgbotxx/objects/UserProfileAudios.hpp>
 #include <tgbotxx/objects/WebhookInfo.hpp>
 #include <tgbotxx/objects/LinkPreviewOptions.hpp>
 #include <tgbotxx/objects/SuggestedPostParameters.hpp>
@@ -1466,6 +1467,20 @@ Ptr<UserProfilePhotos> Api::getUserProfilePhotos(std::int64_t userId,
   return userProfilePhotos;
 }
 
+Ptr<UserProfileAudios> Api::getUserProfileAudios(std::int64_t userId,
+                                                 std::int32_t offset,
+                                                 std::int32_t limit) const {
+  cpr::Multipart data{};
+  data.parts.reserve(3);
+  data.parts.emplace_back("user_id", std::to_string(userId));
+  if (offset)
+    data.parts.emplace_back("offset", offset);
+  if (limit)
+    data.parts.emplace_back("limit", limit);
+
+  return makePtr<UserProfileAudios>(sendRequest("getUserProfileAudios", data));
+}
+
 Ptr<File> Api::getFile(const std::string& fileId) const {
   cpr::Multipart data{};
   data.parts.reserve(1);
@@ -2167,6 +2182,18 @@ Ptr<BotShortDescription> Api::getMyShortDescription(const std::string& languageC
 
   const nl::json botShortDescObj = sendRequest("getMyShortDescription", data);
   return makePtr<BotShortDescription>(botShortDescObj);
+}
+
+bool Api::setMyProfilePhoto(const Ptr<InputProfilePhoto>& photo) const {
+  cpr::Multipart data{};
+  data.parts.reserve(1);
+  data.parts.emplace_back("photo", photo->toJson().dump());
+
+  return sendRequest("setMyProfilePhoto", data);
+}
+
+bool Api::removeMyProfilePhoto() const {
+  return sendRequest("removeMyProfilePhoto");
 }
 
 bool Api::setChatMenuButton(const std::variant<std::int64_t, std::string>& chatId, const Ptr<tgbotxx::MenuButton>& menuButton) const {

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -2546,14 +2546,15 @@ Ptr<OwnedGifts> Api::getBusinessAccountGifts(const std::string& businessConnecti
                                              bool excludeUnsaved,
                                              bool excludeSaved,
                                              bool excludeUnlimited,
-                                             bool excludeLimitedUpgradable = false,
-                                             bool excludeLimitedNonUpgradable = false,
+                                             bool excludeLimitedUpgradable,
+                                             bool excludeLimitedNonUpgradable,
                                              bool excludeUnique,
+                                             bool excludeFromBlockchain,
                                              bool sortByPrice,
                                              const std::string& offset,
                                              std::int32_t limit) const {
   cpr::Multipart data{};
-  data.parts.reserve(10);
+  data.parts.reserve(11);
   data.parts.emplace_back("business_connection_id", businessConnectionId);
   if (excludeUnsaved)
     data.parts.emplace_back("exclude_unsaved", excludeUnsaved);
@@ -2567,6 +2568,8 @@ Ptr<OwnedGifts> Api::getBusinessAccountGifts(const std::string& businessConnecti
     data.parts.emplace_back("exclude_limited_non_upgradable", excludeLimitedNonUpgradable);
   if (excludeUnique)
     data.parts.emplace_back("exclude_unique", excludeUnique);
+  if (excludeFromBlockchain)
+    data.parts.emplace_back("exclude_from_blockchain", excludeFromBlockchain);
   if (sortByPrice)
     data.parts.emplace_back("sort_by_price", sortByPrice);
   data.parts.emplace_back("offset", offset);

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -2285,6 +2285,87 @@ bool Api::giftPremiumSubscription(std::int64_t userId,
   return sendRequest("giftPremiumSubscription", data);
 }
 
+Ptr<OwnedGifts> Api::getUserGifts(std::int64_t userId,
+                                  bool excludeUnlimited,
+                                  bool excludeLimitedUpgradable,
+                                  bool excludeLimitedNonUpgradable,
+                                  bool excludeFromBlockchain,
+                                  bool excludeUnique,
+                                  bool sortByPrice,
+                                  const std::string& offset,
+                                  std::int32_t limit) const {
+  cpr::Multipart data{};
+  data.parts.reserve(9);
+  data.parts.emplace_back("user_id", std::to_string(userId));
+  if (excludeUnlimited)
+    data.parts.emplace_back("exclude_unlimited", excludeUnlimited);
+  if (excludeLimitedUpgradable)
+    data.parts.emplace_back("exclude_limited_upgradable", excludeLimitedUpgradable);
+  if (excludeLimitedNonUpgradable)
+    data.parts.emplace_back("exclude_limited_non_upgradable", excludeLimitedNonUpgradable);
+  if (excludeFromBlockchain)
+    data.parts.emplace_back("exclude_from_blockchain", excludeFromBlockchain);
+  if (excludeUnique)
+    data.parts.emplace_back("exclude_unique", excludeUnique);
+  if (sortByPrice)
+    data.parts.emplace_back("sort_by_price", sortByPrice);
+  if (not offset.empty())
+    data.parts.emplace_back("offset", offset);
+  if (limit)
+    data.parts.emplace_back("limit", limit);
+  return makePtr<OwnedGifts>(sendRequest("getUserGifts", data));
+}
+
+Ptr<OwnedGifts> Api::getChatGifts(const std::variant<std::int64_t, std::string>& chatId,
+                                  bool excludeUnsaved,
+                                  bool excludeSaved,
+                                  bool excludeUnlimited,
+                                  bool excludeLimitedUpgradable,
+                                  bool excludeLimitedNonUpgradable,
+                                  bool excludeFromBlockchain,
+                                  bool excludeUnique,
+                                  bool sortByPrice,
+                                  const std::string& offset,
+                                  std::int32_t limit) const {
+  cpr::Multipart data{};
+  data.parts.reserve(11);
+  switch (chatId.index()) {
+    case 0: // std::int64_t
+      if (std::int64_t chatIdInt = std::get<std::int64_t>(chatId); chatIdInt != 0) {
+        data.parts.emplace_back("chat_id", std::to_string(chatIdInt));
+      }
+      break;
+    case 1: // std::string
+      if (std::string chatIdStr = std::get<std::string>(chatId); not chatIdStr.empty()) {
+        data.parts.emplace_back("chat_id", chatIdStr);
+      }
+      break;
+    default:
+      break;
+  }
+  if (excludeUnsaved)
+    data.parts.emplace_back("exclude_unsaved", excludeUnsaved);
+  if (excludeSaved)
+    data.parts.emplace_back("exclude_saved", excludeSaved);
+  if (excludeUnlimited)
+    data.parts.emplace_back("exclude_unlimited", excludeUnlimited);
+  if (excludeLimitedUpgradable)
+    data.parts.emplace_back("exclude_limited_upgradable", excludeLimitedUpgradable);
+  if (excludeLimitedNonUpgradable)
+    data.parts.emplace_back("exclude_limited_non_upgradable", excludeLimitedNonUpgradable);
+  if (excludeFromBlockchain)
+    data.parts.emplace_back("exclude_from_blockchain", excludeFromBlockchain);
+  if (excludeUnique)
+    data.parts.emplace_back("exclude_unique", excludeUnique);
+  if (sortByPrice)
+    data.parts.emplace_back("sort_by_price", sortByPrice);
+  if (not offset.empty())
+    data.parts.emplace_back("offset", offset);
+  if (limit)
+    data.parts.emplace_back("limit", limit);
+  return makePtr<OwnedGifts>(sendRequest("getChatGifts", data));
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////
 bool Api::verifyUser(std::int64_t userId,
                      const std::string& customDescription) const {

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -2546,13 +2546,14 @@ Ptr<OwnedGifts> Api::getBusinessAccountGifts(const std::string& businessConnecti
                                              bool excludeUnsaved,
                                              bool excludeSaved,
                                              bool excludeUnlimited,
-                                             bool excludeLimited,
+                                             bool excludeLimitedUpgradable = false,
+                                             bool excludeLimitedNonUpgradable = false,
                                              bool excludeUnique,
                                              bool sortByPrice,
                                              const std::string& offset,
                                              std::int32_t limit) const {
   cpr::Multipart data{};
-  data.parts.reserve(9);
+  data.parts.reserve(10);
   data.parts.emplace_back("business_connection_id", businessConnectionId);
   if (excludeUnsaved)
     data.parts.emplace_back("exclude_unsaved", excludeUnsaved);
@@ -2560,8 +2561,10 @@ Ptr<OwnedGifts> Api::getBusinessAccountGifts(const std::string& businessConnecti
     data.parts.emplace_back("exclude_saved", excludeSaved);
   if (excludeUnlimited)
     data.parts.emplace_back("exclude_unlimited", excludeUnlimited);
-  if (excludeLimited)
-    data.parts.emplace_back("exclude_limited", excludeLimited);
+  if (excludeLimitedUpgradable)
+    data.parts.emplace_back("exclude_limited_upgradable", excludeLimitedUpgradable);
+  if (excludeLimitedNonUpgradable)
+    data.parts.emplace_back("exclude_limited_non_upgradable", excludeLimitedNonUpgradable);
   if (excludeUnique)
     data.parts.emplace_back("exclude_unique", excludeUnique);
   if (sortByPrice)

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -1383,6 +1383,31 @@ Ptr<Message> Api::sendDice(const std::variant<std::int64_t, std::string>& chatId
   return message;
 }
 
+bool Api::sendMessageDraft(std::int64_t chatId,
+                           std::int64_t draftId,
+                           const std::string& text,
+                           std::int32_t messageThreadId,
+                           const std::string& parseMode,
+                           const std::vector<Ptr<MessageEntity>>& entities) const {
+  cpr::Multipart data{};
+  data.parts.reserve(6);
+  data.parts.emplace_back("chat_id", std::to_string(chatId));
+  data.parts.emplace_back("draft_id", std::to_string(draftId));
+  data.parts.emplace_back("text", text);
+  if (messageThreadId)
+    data.parts.emplace_back("message_thread_id", messageThreadId);
+  if (not parseMode.empty())
+    data.parts.emplace_back("parse_mode", parseMode);
+  if (not entities.empty()) {
+    nl::json entitiesArray = nl::json::array();
+    for (const Ptr<MessageEntity>& entity: entities)
+      entitiesArray.push_back(entity->toJson());
+    data.parts.emplace_back("entities", entitiesArray.dump());
+  }
+
+  return sendRequest("sendMessageDraft", data);
+}
+
 bool Api::sendChatAction(const std::variant<std::int64_t, std::string>& chatId,
                          const std::string& action,
                          std::int32_t messageThreadId,

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -1582,7 +1582,8 @@ bool Api::promoteChatMember(const std::variant<std::int64_t, std::string>& chatI
                             bool canEditStories,
                             bool canDeleteStories,
                             bool canManageTopics,
-                            bool canManageDirectMessages) const {
+                            bool canManageDirectMessages,
+                            bool canManageTags) const {
   cpr::Multipart data{};
   data.parts.reserve(18);
   data.parts.emplace_back("chat_id", chatId.index() == 0 ? std::to_string(std::get<0>(chatId)) : std::get<1>(chatId));
@@ -1619,6 +1620,8 @@ bool Api::promoteChatMember(const std::variant<std::int64_t, std::string>& chatI
     data.parts.emplace_back("can_manage_topics", canManageTopics);
   if (canManageDirectMessages)
     data.parts.emplace_back("can_manage_direct_messages", canManageDirectMessages);
+  if (canManageTags)
+    data.parts.emplace_back("can_manage_tags", canManageTags);
   return sendRequest("promoteChatMember", data);
 }
 
@@ -2244,6 +2247,19 @@ Ptr<ChatAdministratorRights> Api::getMyDefaultAdministratorRights(bool forChanne
     data.parts.emplace_back("for_channels", forChannels);
   const nl::json chatAdministratorRightsObj = sendRequest("getMyDefaultAdministratorRights", data);
   return makePtr<ChatAdministratorRights>(chatAdministratorRightsObj);
+}
+
+bool Api::setChatMemberTag(const std::variant<std::int64_t, std::string>& chatId,
+                           std::int64_t userId,
+                           const std::string& tag) const {
+  cpr::Multipart data{};
+  data.parts.reserve(3);
+  data.parts.emplace_back("chat_id", chatId.index() == 0 ? std::to_string(std::get<0>(chatId)) : std::get<1>(chatId));
+  data.parts.emplace_back("user_id", std::to_string(userId));
+  if (not tag.empty())
+    data.parts.emplace_back("tag", tag);
+
+  return sendRequest("setChatMemberTag", data);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -940,24 +940,18 @@ Ptr<Message> Api::sendPaidMedia(const std::variant<std::int64_t, std::string>& c
   // Handle local media files if available, see https://core.telegram.org/bots/api#inputmediaphoto
   for (const Ptr<InputPaidMedia>& m: media) {
     nl::json mJson = m->toJson();
-    switch (m->media.index()) {
-      case 0: // cpr::File (Local File)
-      {
+    if (not std::holds_alternative<std::monostate>(m->media)) {
+      // media variant
+      if (std::holds_alternative<cpr::File>(m->media)) { // cpr::File (Local File)
         const cpr::File& file = std::get<cpr::File>(m->media);
         std::string fileKey = StringUtils::random(8);
         mJson["media"] = "attach://" + fileKey;
         data.parts.emplace_back(fileKey, cpr::Files{file});
-        break;
-      }
-      case 1: // std::string (URL, File ID)
-      {
+      } else { // std::string (URL, File ID)
         // do nothing as toJson will export the "media": "URL or file ID" object.
-        break;
       }
-      default:
-        break;
     }
-    mediaJson.push_back(mJson);
+    mediaJson.emplace_back(mJson);
   }
   data.parts.emplace_back("media", mediaJson.dump());
   if (not payload.empty())
@@ -1018,24 +1012,18 @@ std::vector<Ptr<Message>> Api::sendMediaGroup(const std::variant<std::int64_t, s
   // Handle local media files if available, see https://core.telegram.org/bots/api#inputmediaphoto
   for (const Ptr<InputMedia>& m: media) {
     nl::json mJson = m->toJson();
-    switch (m->media.index()) {
-      case 0: // cpr::File (Local File)
-      {
+    if (not std::holds_alternative<std::monostate>(m->media)) {
+      // media variant
+      if (std::holds_alternative<cpr::File>(m->media)) { // cpr::File (Local File)
         const cpr::File& file = std::get<cpr::File>(m->media);
         std::string fileKey = StringUtils::random(8);
         mJson["media"] = "attach://" + fileKey;
         data.parts.emplace_back(fileKey, cpr::Files{file});
-        break;
-      }
-      case 1: // std::string (URL, File ID)
-      {
+      } else { // std::string (URL, File ID)
         // do nothing as toJson will export the "media": "URL or file ID" object.
-        break;
       }
-      default:
-        break;
     }
-    mediaJson.push_back(mJson);
+    mediaJson.emplace_back(mJson);
   }
   data.parts.emplace_back("media", mediaJson.dump());
   if (messageThreadId)

--- a/src/objects/ChatFullInfo.cpp
+++ b/src/objects/ChatFullInfo.cpp
@@ -7,6 +7,7 @@ ChatFullInfo::ChatFullInfo(const nl::json& json) {
 
 nl::json ChatFullInfo::toJson() const {
   nl::json json = Chat::toJson();
+  // @note: id, title, username, firstName...etc. are handled by parent Chat
   OBJECT_SERIALIZE_FIELD(json, "accent_color_id", accentColorId);
   OBJECT_SERIALIZE_FIELD(json, "max_reaction_count", maxReactionCount);
   OBJECT_SERIALIZE_FIELD_PTR(json, "photo", photo);
@@ -43,12 +44,17 @@ nl::json ChatFullInfo::toJson() const {
   OBJECT_SERIALIZE_FIELD(json, "custom_emoji_sticker_set_name", customEmojiStickerSetName);
   OBJECT_SERIALIZE_FIELD(json, "linked_chat_id", linkedChatId);
   OBJECT_SERIALIZE_FIELD_PTR(json, "location", location);
+  OBJECT_SERIALIZE_FIELD_PTR(json, "rating", rating);
+  OBJECT_SERIALIZE_FIELD_PTR(json, "first_profile_audio", firstProfileAudio);
+  OBJECT_SERIALIZE_FIELD_PTR(json, "unique_gift_colors", uniqueGiftColors);
+  OBJECT_SERIALIZE_FIELD(json, "paid_message_star_count", paidMessageStarCount);
   return json;
 }
 
 
 void ChatFullInfo::fromJson(const nl::json& json) {
   Chat::fromJson(json);
+  // @note: id, title, username, firstName...etc. are handled by parent Chat
   OBJECT_DESERIALIZE_FIELD(json, "accent_color_id", accentColorId, 0, true);
   OBJECT_DESERIALIZE_FIELD(json, "max_reaction_count", maxReactionCount, 0, false);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "photo", photo, true);
@@ -85,4 +91,8 @@ void ChatFullInfo::fromJson(const nl::json& json) {
   OBJECT_DESERIALIZE_FIELD(json, "custom_emoji_sticker_set_name", customEmojiStickerSetName, "", true);
   OBJECT_DESERIALIZE_FIELD(json, "linked_chat_id", linkedChatId, 0, true);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "location", location, true);
+  OBJECT_DESERIALIZE_FIELD_PTR(json, "rating", rating, true);
+  OBJECT_DESERIALIZE_FIELD_PTR(json, "first_profile_audio", firstProfileAudio, true);
+  OBJECT_DESERIALIZE_FIELD_PTR(json, "unique_gift_colors", uniqueGiftColors, true);
+  OBJECT_DESERIALIZE_FIELD(json, "paid_message_star_count", paidMessageStarCount, 0, true);
 }

--- a/src/objects/Message.cpp
+++ b/src/objects/Message.cpp
@@ -21,6 +21,7 @@ nl::json Message::toJson() const {
   OBJECT_SERIALIZE_FIELD_PTR(json, "sender_chat", senderChat);
   OBJECT_SERIALIZE_FIELD(json, "sender_boost_count", senderBoostCount);
   OBJECT_SERIALIZE_FIELD_PTR(json, "sender_business_bot", senderBusinessBot);
+  OBJECT_SERIALIZE_FIELD(json, "sender_tag", senderTag);
   OBJECT_SERIALIZE_FIELD(json, "date", date);
   OBJECT_SERIALIZE_FIELD(json, "business_connection_id", businessConnectionId);
   OBJECT_SERIALIZE_FIELD_PTR(json, "chat", chat);
@@ -134,6 +135,7 @@ void Message::fromJson(const nl::json& json) {
   OBJECT_DESERIALIZE_FIELD_PTR(json, "sender_chat", senderChat, true);
   OBJECT_DESERIALIZE_FIELD(json, "sender_boost_count", senderBoostCount, 0, true);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "sender_business_bot", senderBusinessBot, true);
+  OBJECT_DESERIALIZE_FIELD(json, "sender_tag", senderTag, "", true);
   OBJECT_DESERIALIZE_FIELD(json, "date", date, 0, false);
   OBJECT_DESERIALIZE_FIELD(json, "business_connection_id", businessConnectionId, "", true);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "chat", chat, false);

--- a/src/objects/Message.cpp
+++ b/src/objects/Message.cpp
@@ -87,6 +87,7 @@ nl::json Message::toJson() const {
   OBJECT_SERIALIZE_FIELD_PTR(json, "chat_shared", chatShared);
   OBJECT_SERIALIZE_FIELD_PTR(json, "gift", gift);
   OBJECT_SERIALIZE_FIELD_PTR(json, "unique_gift", uniqueGift);
+  OBJECT_SERIALIZE_FIELD_PTR(json, "gift_upgrade_sent", giftUpgradeSent);
   OBJECT_SERIALIZE_FIELD(json, "connected_website", connectedWebsite);
   OBJECT_SERIALIZE_FIELD_PTR(json, "write_access_allowed", writeAccessAllowed);
   OBJECT_SERIALIZE_FIELD_PTR(json, "passport_data", passportData);
@@ -205,6 +206,7 @@ void Message::fromJson(const nl::json& json) {
   OBJECT_DESERIALIZE_FIELD_PTR(json, "chat_shared", chatShared, true);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "gift", gift, true);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "unique_gift", uniqueGift, true);
+  OBJECT_DESERIALIZE_FIELD_PTR(json, "gift_upgrade_sent", giftUpgradeSent, true);
   OBJECT_DESERIALIZE_FIELD(json, "connected_website", connectedWebsite, "", true);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "write_access_allowed", writeAccessAllowed, true);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "passport_data", passportData, true);

--- a/src/objects/Message.cpp
+++ b/src/objects/Message.cpp
@@ -8,6 +8,8 @@
 #include <tgbotxx/objects/SuggestedPostDeclined.hpp>
 #include <tgbotxx/objects/SuggestedPostPaid.hpp>
 #include <tgbotxx/objects/SuggestedPostRefunded.hpp>
+#include <tgbotxx/objects/ChatOwnerLeft.hpp>
+#include <tgbotxx/objects/ChatOwnerChanged.hpp>
 using namespace tgbotxx;
 
 nl::json Message::toJson() const {
@@ -65,6 +67,8 @@ nl::json Message::toJson() const {
   OBJECT_SERIALIZE_FIELD_PTR(json, "location", location);
   OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, "new_chat_members", newChatMembers);
   OBJECT_SERIALIZE_FIELD_PTR(json, "left_chat_member", leftChatMember);
+  OBJECT_SERIALIZE_FIELD_PTR(json, "chat_owner_left", chatOwnerLeft);
+  OBJECT_SERIALIZE_FIELD_PTR(json, "chat_owner_changed", chatOwnerChanged);
   OBJECT_SERIALIZE_FIELD(json, "new_chat_title", newChatTitle);
   OBJECT_SERIALIZE_FIELD_PTR_ARRAY(json, "new_chat_photo", newChatPhoto);
   OBJECT_SERIALIZE_FIELD(json, "delete_chat_photo", deleteChatPhoto);
@@ -176,6 +180,8 @@ void Message::fromJson(const nl::json& json) {
   OBJECT_DESERIALIZE_FIELD_PTR(json, "location", location, true);
   OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, "new_chat_members", newChatMembers, true);
   OBJECT_DESERIALIZE_FIELD_PTR(json, "left_chat_member", leftChatMember, true);
+  OBJECT_DESERIALIZE_FIELD_PTR(json, "chat_owner_left", chatOwnerLeft, true);
+  OBJECT_DESERIALIZE_FIELD_PTR(json, "chat_owner_changed", chatOwnerChanged, true);
   OBJECT_DESERIALIZE_FIELD(json, "new_chat_title", newChatTitle, "", true);
   OBJECT_DESERIALIZE_FIELD_PTR_ARRAY(json, "new_chat_photo", newChatPhoto, true);
   OBJECT_DESERIALIZE_FIELD(json, "delete_chat_photo", deleteChatPhoto, false, true);

--- a/src/objects/User.cpp
+++ b/src/objects/User.cpp
@@ -20,6 +20,7 @@ nl::json User::toJson() const {
   OBJECT_SERIALIZE_FIELD(user, "can_connect_to_business", canConnectToBusiness);
   OBJECT_SERIALIZE_FIELD(user, "has_main_web_app", hasMainWebApp);
   OBJECT_SERIALIZE_FIELD(user, "has_topics_enabled", hasTopicsEnabled);
+  OBJECT_SERIALIZE_FIELD(user, "allows_users_to_create_topics", allowsUsersToCreateTopics);
   return user;
 }
 
@@ -38,4 +39,5 @@ void User::fromJson(const nl::json &json) {
   OBJECT_DESERIALIZE_FIELD(json, "can_connect_to_business", canConnectToBusiness, false, true);
   OBJECT_DESERIALIZE_FIELD(json, "has_main_web_app", hasMainWebApp, false, true);
   OBJECT_DESERIALIZE_FIELD(json, "has_topics_enabled", hasTopicsEnabled, false, true);
+  OBJECT_DESERIALIZE_FIELD(json, "allows_users_to_create_topics", allowsUsersToCreateTopics, false, true);
 }

--- a/src/objects/User.cpp
+++ b/src/objects/User.cpp
@@ -19,6 +19,7 @@ nl::json User::toJson() const {
   OBJECT_SERIALIZE_FIELD(user, "supports_inline_queries", supportsInlineQueries);
   OBJECT_SERIALIZE_FIELD(user, "can_connect_to_business", canConnectToBusiness);
   OBJECT_SERIALIZE_FIELD(user, "has_main_web_app", hasMainWebApp);
+  OBJECT_SERIALIZE_FIELD(user, "has_topics_enabled", hasTopicsEnabled);
   return user;
 }
 
@@ -36,4 +37,5 @@ void User::fromJson(const nl::json &json) {
   OBJECT_DESERIALIZE_FIELD(json, "supports_inline_queries", supportsInlineQueries, false, true);
   OBJECT_DESERIALIZE_FIELD(json, "can_connect_to_business", canConnectToBusiness, false, true);
   OBJECT_DESERIALIZE_FIELD(json, "has_main_web_app", hasMainWebApp, false, true);
+  OBJECT_DESERIALIZE_FIELD(json, "has_topics_enabled", hasTopicsEnabled, false, true);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,9 @@
 file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+
+## Catch2
+add_library(catch2 STATIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/catch2/src/catch.cpp)
+target_include_directories(catch2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib/catch2/include)
+
 ## CTest
 foreach (source ${TEST_SOURCES})
     get_filename_component(filename ${source} NAME_WE)
@@ -7,7 +12,10 @@ foreach (source ${TEST_SOURCES})
     target_compile_features(${filename} PRIVATE cxx_std_20)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/catch2/include)
     # Link the tests with the main project tgbotxx
-    target_link_libraries(${filename} PRIVATE tgbotxx)
+    target_link_libraries(${filename} PRIVATE catch2 tgbotxx)
+    target_compile_options(${filename}
+            PRIVATE # Fix ".obj file too big" issue in windows/mingw
+            $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>>:-Wa,-mbig-obj>)
     if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         # valgrind memory leak checks (NOTE: valgrind has problems with clang symbols, compile with gcc before running this target)
         add_custom_target(check_memory_leaks_${filename}

--- a/tests/lib/catch2/src/catch.cpp
+++ b/tests/lib/catch2/src/catch.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch.hpp>

--- a/tests/manual_tests.cpp
+++ b/tests/manual_tests.cpp
@@ -301,6 +301,12 @@ private: // Command handlers
       Ptr<InlineKeyboardButton> button(new InlineKeyboardButton());
       button->text = std::to_string(i);
       button->callbackData = button->text;
+      switch (i) {
+        case 0: button->style = "danger"; break;
+        case 1: button->style = "success"; break;
+        case 9: button->style = "primary"; break;
+        default: break;
+      }
       row.push_back(button);
       if (i % 3 == 0 || !i) {
         keyboard->inlineKeyboard.push_back(row);
@@ -308,6 +314,7 @@ private: // Command handlers
       }
     }
     std::ranges::reverse(keyboard->inlineKeyboard);
+
     api()->sendMessage(message->chat->id, "Buttons:", 0, "", {}, false, false, keyboard);
   }
   void handleCommandReplyKeyboardButtons(const Ptr<Message>& message) {
@@ -330,13 +337,16 @@ private: // Command handlers
     button1->text = "Button1";
     row1.push_back(button1);
     Ptr<KeyboardButton> button2(new KeyboardButton());
-    button2->text = "Button2";
+    button2->text = "Button2 (style=success)";
+    button2->style = "success";
     row1.push_back(button2);
     Ptr<KeyboardButton> button3(new KeyboardButton());
-    button3->text = "Button3";
+    button3->text = "Button3 (style=primary)";
+    button3->style = "primary";
     row2.push_back(button3);
     Ptr<KeyboardButton> button4(new KeyboardButton());
-    button4->text = "Button4";
+    button4->text = "Button4 (style=danger)";
+    button4->style = "danger";
     row2.push_back(button4);
     replyKeyboardMarkup->keyboard.push_back(row1);
     replyKeyboardMarkup->keyboard.push_back(row2);

--- a/tests/manual_tests.cpp
+++ b/tests/manual_tests.cpp
@@ -68,7 +68,7 @@ private:
     //      api()->setLongPollTimeout(std::chrono::seconds(60 * 2));
     // Drop awaiting updates (when Bot is not running, updates will remain 24 hours
     // in Telegram server before they get deleted or retrieved by BOT)
-    //api()->deleteWebhook(true);
+    api()->deleteWebhook(true);
     api()->setLongPollTimeout(cpr::Timeout(std::chrono::seconds(300)));
     api()->setUpdatesLimit(3); // memory tight? process updates 3 by 3...
     assert(api()->getUpdatesLimit() == 3);
@@ -165,7 +165,11 @@ private:
       // look for /start or /start@myusername (in groups)
       if (command == message->text or message->text == command + atMyUsername) {
         // Call the proper command handler
-        (this->*handler)(message);
+        try {
+          (this->*handler)(message);
+        } catch (const std::exception& e) {
+          std::cerr << command << " handler threw an exception: " << e.what() << std::endl;
+        }
         break;
       }
     }
@@ -602,13 +606,15 @@ private: // Command handlers
                                  "https://images2.alphacoders.com/131/1311487.jpg"}) {
       Ptr<InputPaidMediaPhoto> photo(new InputPaidMediaPhoto());
       photo->media = url;
+      assert(photo->type == "photo");
       paidMedia.push_back(photo);
     }
     // add local video to the order list
     Ptr<InputPaidMediaVideo> video(new InputPaidMediaVideo());
     video->media = cpr::File{(fs::path(__FILE__).parent_path().parent_path() / "examples/sendVideo/videos/video.mp4").string()}; // Local
-    video->startTimestamp = 3;                                                                                                   // start from 3rd second
+    video->startTimestamp = std::rand() % 10;                                                                                                   // start from 3rd second
     video->supportsStreaming = true;
+    assert(video->type == "video");
     paidMedia.push_back(video);
 
     constexpr std::int32_t starsPrice = 100;

--- a/tests/manual_tests.cpp
+++ b/tests/manual_tests.cpp
@@ -48,6 +48,7 @@ class MyBot final : public Bot {
     {{"/create_invoice_link", "You will receive a test invoice link"}, &MyBot::handleCommandCreateInvoiceLink},
     {{"/test_bot_blocked_by_user", "Block the bot within 10s after u receive a message"}, &MyBot::handleCommandTestBotBlockedByUser},
     {{"/send_paid_media", "send paid media to be unlocked with stars"}, &MyBot::handleCommandSendPaidMedia},
+    {{"/send_message_draft", "stream a partial message to a user while the message is being generated"}, &MyBot::handleCommandSendMessageDraft},
   };
 
 public:
@@ -63,7 +64,7 @@ private:
   /// Called before Bot starts receiving updates (triggered by Bot::start())
   /// Use this callback to initialize your code, set commands..
   void onStart() override {
-
+    std::srand(std::time(nullptr));
     //      api()->setTimeout(std::chrono::seconds(60 * 3));
     //      api()->setLongPollTimeout(std::chrono::seconds(60 * 2));
     // Drop awaiting updates (when Bot is not running, updates will remain 24 hours
@@ -621,6 +622,26 @@ private: // Command handlers
     std::string payload = "some payload to receive back if this got purchased";
     api()->sendPaidMedia(message->from->id, starsPrice, paidMedia, payload);
     // the user will get access to the photos only after the payment is completed
+  }
+
+  void handleCommandSendMessageDraft(const Ptr<Message>& message) {
+    using namespace std::chrono_literals;
+    bool ok = true;
+
+    const std::int64_t draftId = std::rand() % INT32_MAX;
+
+    ok &= api()->sendMessageDraft(message->chat->id, draftId, "Hello, this is a draft message with id=" + std::to_string(draftId));
+    assert(ok);
+
+    std::this_thread::sleep_for(2s);
+
+    ok &= api()->sendMessageDraft(message->chat->id, draftId, "and it just got edited!");
+    assert(ok);
+
+    std::this_thread::sleep_for(2s);
+
+    ok &= api()->sendMessageDraft(message->chat->id, draftId, "Final edit.");
+    assert(ok);
   }
 
 

--- a/tests/src/TestUtils.cpp
+++ b/tests/src/TestUtils.cpp
@@ -81,24 +81,57 @@ TEST_CASE("DateTimeUtils", "all functions") {
     Catch::cout() << nowStr << std::endl;
     Catch::cout() << oneHourFromNowStr << std::endl;
     Catch::cout() << oneHourBeforeNowStr << std::endl;
+
+    REQUIRE(nowStr != oneHourFromNowStr);
+    REQUIRE(nowStr != oneHourBeforeNowStr);
   }
+
   SECTION("fromString") {
-    {
-      std::string str = "1970-01-01";
-      std::time_t dt = DateTimeUtils::fromString(str, "%Y-%m-%d");
-      std::string rec = DateTimeUtils::toString(dt, "%Y-%m-%d");
-      Catch::cout() << dt << std::endl;
-      Catch::cout() << rec << std::endl;
-      REQUIRE(str == rec);
+    std::string str = "2031/07/18 16:34:34";
+    std::time_t dt = DateTimeUtils::fromString(str, "%Y/%m/%d %H:%M:%S");
+    std::string rec = DateTimeUtils::toString(dt, "%Y/%m/%d %H:%M:%S");
+    Catch::cout() << dt << std::endl;
+    Catch::cout() << rec << std::endl;
+    REQUIRE(str == rec);
+  }
+
+  SECTION("round-trip conversions") {
+    for (int i = 0; i < 10; ++i) {
+      std::time_t now = std::time(nullptr) + (i * 12345);
+      std::string str = DateTimeUtils::toString(now);
+      std::time_t parsed = DateTimeUtils::fromString(str);
+      std::string reconstructed = DateTimeUtils::toString(parsed);
+      Catch::cout() << str << " -> " << reconstructed << std::endl;
+      REQUIRE(str == reconstructed);
     }
-    {
-      std::string str = "2031/07/18 16:34:34";
-      std::time_t dt = DateTimeUtils::fromString(str, "%Y/%m/%d %H:%M:%S");
-      std::string rec = DateTimeUtils::toString(dt, "%Y/%m/%d %H:%M:%S");
-      Catch::cout() << dt << std::endl;
-      Catch::cout() << rec << std::endl;
-      REQUIRE(str == rec);
-    }
+  }
+
+  SECTION("different formats") {
+    std::time_t now = std::time(nullptr);
+
+    std::string f1 = DateTimeUtils::toString(now, "%Y/%m/%d");
+    std::string f2 = DateTimeUtils::toString(now, "%H-%M-%S");
+    std::string f3 = DateTimeUtils::toString(now, "%d-%m-%Y %H:%M");
+
+    Catch::cout() << f1 << std::endl;
+    Catch::cout() << f2 << std::endl;
+    Catch::cout() << f3 << std::endl;
+
+    REQUIRE(!f1.empty());
+    REQUIRE(!f2.empty());
+    REQUIRE(!f3.empty());
+  }
+ SECTION("invalid parsing should fail") {
+    std::string invalid = "not-a-date";
+    auto t = DateTimeUtils::fromString(invalid);
+    REQUIRE(t == -1);
+  }
+
+  SECTION("leap year handling") {
+    std::string leap = "2024-02-29";
+    std::time_t dt = DateTimeUtils::fromString(leap, "%Y-%m-%d");
+    std::string rec = DateTimeUtils::toString(dt, "%Y-%m-%d");
+    REQUIRE(rec == leap);
   }
 }
 


### PR DESCRIPTION
## v1.2.9.5

# What's Changed
# 9.3

### Topics in private chats
- [x] Added the field `has_topics_enabled` to the class `User`, which can be used to determine whether forum topic mode is enabled for the bot in private chats.
- [x] Added the method `sendMessageDraft`, allowing partial messages to be streamed to a user while being generated.
- [x] Supported the fields `message_thread_id` and `is_topic_message` in the class `Message` for messages in private chats with forum topic mode enabled.
- [x] Supported the parameter `message_thread_id` in private chats with topics in the methods `sendMessage`, `sendPhoto`, `sendVideo`, `sendAnimation`, `sendAudio`, `sendDocument`, `sendPaidMedia`, `sendSticker`, `sendVideoNote`, `sendVoice`, `sendLocation`, `sendVenue`, `sendContact`, `sendPoll`, `sendDice`, `sendInvoice`, `sendGame`, `sendMediaGroup`, `copyMessage`, `copyMessages`, `forwardMessage`, and `forwardMessages`.
- [x] Supported the parameter `message_thread_id` in private chats in the method `sendChatAction`.
- [x] Supported the parameter `message_thread_id` in private chats with topics in the methods `editForumTopic`, `deleteForumTopic`, and `unpinAllForumTopicMessages`.
- [x] Added the field `is_name_implicit` to the classes `ForumTopic` and `ForumTopicCreated`.

### Gifts
- [x] Added the methods `getUserGifts` and `getChatGifts`.
- [x] Replaced the field `last_resale_star_count` with the fields `last_resale_currency` and `last_resale_amount` in the class `UniqueGiftInfo`.
- [x] Replaced the parameter `exclude_limited` with the parameters `exclude_limited_upgradable` and `exclude_limited_non_upgradable` in the method `getBusinessAccountGifts`.
- [x] Added the value `"gifted_upgrade"` as a possible value of `UniqueGiftInfo.origin`.
- [x] Added the value `"offer"` as a possible value of `UniqueGiftInfo.origin`.
- [x] Added the field `gift_upgrade_sent` to the class `Message`.
- [x] Added the field `gift_id` to the class `UniqueGift`.
- [x] Added the field `is_from_blockchain` to the class `UniqueGift`.
- [x] Added the parameter `exclude_from_blockchain` in the method `getBusinessAccountGifts`.
- [x] Added the fields `personal_total_count` and `personal_remaining_count` to the class `Gift`.
- [x] Added the field `is_premium` to the classes `Gift` and `UniqueGift`.
- [x] Added the field `is_upgrade_separate` to the classes `GiftInfo` and `OwnedGiftRegular`.
- [x] Added the class `UniqueGiftColors`.
- [x] Added the field `has_colors` to the class `Gift`.
- [x] Added the field `colors` to the class `UniqueGift`.
- [x] Added the class `GiftBackground` and the field `background` to the class `Gift`.
- [x] Added the field `unique_gift_variant_count` to the class `Gift`.
- [x] Added the field `unique_gift_number` to the classes `GiftInfo` and `OwnedGiftRegular`.
- [x] Added the field `gifts_from_channels` to the class `AcceptedGiftTypes`.

### Miscellaneous
- [x] Allowed bots to disable their main username if they have additional active usernames purchased on Fragment.
- [x] Allowed bots to disable the right `can_restrict_members` in channel chats.
- [x] Added the method `repostStory`.
- [x] Added the class `UserRating` and the field `rating` to the class `ChatFullInfo`.
- [x] Increased the maximum price for paid media to 25000 Telegram Stars.
- [x] Added the field `paid_message_star_count` to the class `ChatFullInfo`.
- [x] Added the parameter `message_effect_id` to the methods `forwardMessage` and `copyMessage`.
- [x] Added the field `unique_gift_colors` to the class `ChatFullInfo`.
- [x] Added the field `completed_by_chat` to the class `ChecklistTask`.


# 9.4

### Custom Emoji
- [x] Allowed bots to use custom emoji in messages directly sent by the bot to private, group and supergroup chats if the owner of the bot has a Telegram Premium subscription.

### Topics in Private Chats
- [x] Allowed bots to create topics in private chats using the method `createForumTopic`.
- [x] Allowed bots to prevent users from creating and deleting topics in private chats through a new setting in the @BotFather Mini App.
- [x] Added the field `allows_users_to_create_topics` to the class `User`.

### Button Improvements
- [x] Added the field `icon_custom_emoji_id` to the classes `KeyboardButton` and `InlineKeyboardButton`.
- [x] Added the field `style` to the classes `KeyboardButton` and `InlineKeyboardButton`.

### Chat Ownership
- [x] Added the class `ChatOwnerLeft` and the field `chat_owner_left` to the class `Message`.
- [x] Added the class `ChatOwnerChanged` and the field `chat_owner_changed` to the class `Message`.

### Bot Profile
- [x] Added the methods `setMyProfilePhoto` and `removeMyProfilePhoto`.

### Video Improvements
- [x] Added the class `VideoQuality` and the field `qualities` to the class `Video`.

### Profile Audio
- [x] Added the field `first_profile_audio` to the class `ChatFullInfo`.
- [x] Added the class `UserProfileAudios`.
- [x] Added the method `getUserProfileAudios`.

### Gifts
- [x] Added the field `rarity` to the class `UniqueGiftModel`.
- [x] Added the field `is_burned` to the class `UniqueGift`.


# 9.5

### Message Entities
- [x] Added the `MessageEntity` type `date_time`, allowing bots to show a formatted date and time to the user.

### Draft Messages
- [x] Allowed all bots to use the method `sendMessageDraft`.

### Chat Member Tags
- [x] Added the field `tag` to the classes `ChatMemberMember` and `ChatMemberRestricted`.
- [x] Added the method `setChatMemberTag`.
- [x] Added the field `can_edit_tag` to the classes `ChatMemberRestricted` and `ChatPermissions`.
- [x] Added the field `can_manage_tags` to the classes `ChatMemberAdministrator` and `ChatAdministratorRights`.
- [x] Added the parameter `can_manage_tags` to the method `promoteChatMember`.
- [x] Added the field `sender_tag` to the class `Message`.

**Full Changelog**: https://github.com/baderouaich/tgbotxx/compare/v1.2.9.2...v1.2.9.5
### Supported Api methods & Objects (Telegram Api v9.5  and below)
- :white_check_mark: [Getting updates](https://core.telegram.org/bots/api#getting-updates)
- :white_check_mark: [Available types](https://core.telegram.org/bots/api#available-types)
-  :white_check_mark: [Available methods](https://core.telegram.org/bots/api#available-methods)
- :white_check_mark: [Inline mode](https://core.telegram.org/bots/api#inline-mode)
- :white_check_mark: [Stickers](https://core.telegram.org/bots/api#stickers)
- :white_check_mark: [Updating messages](https://core.telegram.org/bots/api#updating-messages)
- :white_check_mark:  [Payments](https://core.telegram.org/bots/api#payments)
- :white_check_mark: [Telegram Passport](https://core.telegram.org/bots/api#telegram-passport)
- :white_check_mark: [Games](https://core.telegram.org/bots/api#games)

## Demos
See [examples](https://github.com/baderouaich/tgbotxx/examples)
